### PR TITLE
feat(anamnesis): Implement custom anamnesis forms and templates

### DIFF
--- a/docs/formularios-anamnese-personalizaveis.md
+++ b/docs/formularios-anamnese-personalizaveis.md
@@ -1,0 +1,561 @@
+# Formulários de Anamnese Personalizáveis
+
+Este documento descreve a implementação do módulo de templates de anamnese e o novo fluxo de criação, captura por áudio e visualização de anamneses com campos personalizados.
+
+## Objetivo
+
+Antes desta mudança, o formulário de anamnese era fixo: os campos existiam diretamente no schema Prisma, nos schemas Zod, nos componentes React e no prompt usado pelo worker de áudio.
+
+Agora, cada médico pode ter templates próprios de anamnese, com seções e campos configuráveis. O formulário atual continua existindo como o template padrão criado automaticamente para cada perfil.
+
+## Modelo de Dados
+
+Foram adicionados os arquivos e campos abaixo:
+
+- `prisma/schema/form-template.prisma`
+- `prisma/migrations/20260524123000_anamnesis_form_templates/migration.sql`
+- alterações em `prisma/schema/clinical.prisma`
+- alterações em `prisma/schema/users.prisma`
+
+### Novas entidades
+
+`AnamnesisFormTemplate`
+
+Representa um modelo de formulário pertencente a um médico.
+
+Campos principais:
+
+- `profileId`: dono do template.
+- `name`: nome do template.
+- `description`: descrição opcional.
+- `isDefault`: indica o template padrão do médico.
+- `isArchived`: arquivamento lógico.
+- `sections`: seções do formulário.
+- `anamneses`: anamneses criadas com o template.
+
+`AnamnesisFormSection`
+
+Representa uma seção dentro do formulário, por exemplo `Anamnese`, `Exame Físico` ou `Hipótese e Conduta`.
+
+Campos principais:
+
+- `templateId`: template pai.
+- `name`: nome da seção.
+- `description`: descrição opcional.
+- `order`: posição no formulário.
+- `isCollapsible`: preparado para UI com seções recolhíveis.
+- `fields`: campos da seção.
+
+`AnamnesisFormField`
+
+Representa um campo renderizável.
+
+Campos principais:
+
+- `sectionId`: seção pai.
+- `key`: chave usada para salvar/ler a resposta.
+- `label`: texto exibido na UI.
+- `description`: ajuda opcional.
+- `order`: posição dentro da seção.
+- `fieldType`: tipo do campo.
+- `isRequired`: validação obrigatória.
+- `isVisible`: permite ocultar campos.
+- `config`: JSON com opções e detalhes de configuração.
+- `isSystemField`: indica campo do sistema.
+- `systemKey`: chave original do campo fixo do schema.
+
+### Tipos de campo
+
+O enum `FormFieldType` suporta:
+
+- `TEXT`
+- `SHORT_TEXT`
+- `NUMBER`
+- `BOOLEAN`
+- `SELECT`
+- `RADIO`
+- `DATE`
+- `NYHA_CLASS`
+- `MEDICATIONS`
+
+### Alterações em `Anamnesis`
+
+A tabela `Anamnesis` ganhou:
+
+- `templateId`: FK opcional para o template usado.
+- `customResponses`: JSON com respostas de campos personalizados.
+
+Os campos clínicos críticos e já existentes continuam como colunas tipadas, por exemplo:
+
+- `chiefComplaint`
+- `currentIllnessHistory`
+- `nyhaClass`
+- sintomas booleanos
+- `PhysicalExam`
+- `PrescribedMedication`
+- `diagnosticHypothesis`
+- `conduct`
+- `nextRecallDate`
+
+Essa abordagem mantém compatibilidade com relatórios e filtros existentes, mas permite extensão via JSON para campos customizados.
+
+## Template Padrão
+
+O template padrão é criado pelo service:
+
+`src/server/services/formTemplate.service.ts`
+
+A função principal é:
+
+`seedDefaultTemplate(db, profileId)`
+
+Ela cria o template `Formulario Padrao` de forma idempotente. Se o médico já tiver um template default, nada é duplicado.
+
+O template padrão reproduz o formulário antigo:
+
+Seção `Anamnese`:
+
+- `chiefComplaint`
+- `currentIllnessHistory`
+- `treatmentResponse`
+- `symptomEvolution`
+- `newEvents`
+- `nyhaClass`
+- `hasPalpitations`
+- `hasSyncope`
+- `hasEdema`
+- `hasChestPain`
+
+Seção `Exame Fisico`:
+
+- `weight`
+- `height`
+- `bpSystolic`
+- `bpDiastolic`
+- `heartRate`
+- `oxygenSaturation`
+- `heartAuscultation`
+- `lungAuscultation`
+- `peripheralPulses`
+- `edemaGrade`
+
+Seção `Hipotese e Conduta`:
+
+- `medications`
+- `diagnosticHypothesis`
+- `conduct`
+- `nextRecallDate`
+
+## Backend
+
+### Schemas Zod
+
+Foi criado:
+
+`src/schemas/form-template.ts`
+
+Ele define:
+
+- `formFieldTypeSchema`
+- `formFieldConfigSchema`
+- `upsertFormFieldSchema`
+- `upsertFormSectionSchema`
+- `createFormTemplateSchema`
+- `updateFormTemplateSchema`
+- lista de chaves de campos sistema
+
+Também foram atualizados:
+
+- `src/schemas/anamnesis.ts`
+- `src/schemas/audio-anamnesis-form.ts`
+
+`createAnamnesisSchema` e `updateAnamnesisSchema` agora aceitam:
+
+- `templateId`
+- `customResponses`
+
+`consolidatedFormStateSchema`, usado no áudio, agora aceita:
+
+- `customFields`
+- `templateId`
+
+### Service de Templates
+
+Arquivo:
+
+`src/server/services/formTemplate.service.ts`
+
+Funções principais:
+
+- `getDefaultTemplate`
+- `seedDefaultTemplate`
+- `listTemplates`
+- `getTemplateById`
+- `createTemplate`
+- `updateTemplate`
+- `setDefaultTemplate`
+- `duplicateTemplate`
+- `archiveTemplate`
+- `sanitizeCustomResponses`
+
+Regras importantes:
+
+- Campos do sistema não podem ser removidos.
+- Campos do sistema não podem ter `fieldType` alterado.
+- Campos do sistema podem ser ocultados via `isVisible`.
+- Ao definir um template como default, o service desmarca o default anterior em transação.
+- Templates são arquivados, não deletados.
+
+### Router tRPC
+
+Foi criado:
+
+`src/server/api/routers/formTemplate.router.ts`
+
+Registrado em:
+
+`src/server/api/root.ts`
+
+Endpoints:
+
+- `formTemplate.getDefault`
+- `formTemplate.list`
+- `formTemplate.getById`
+- `formTemplate.create`
+- `formTemplate.update`
+- `formTemplate.setDefault`
+- `formTemplate.duplicate`
+- `formTemplate.archive`
+
+### Criação de Perfil
+
+Arquivo alterado:
+
+`src/server/services/profile.service.ts`
+
+Ao criar ou buscar um perfil, o sistema garante:
+
+- bônus de cadastro
+- template padrão de anamnese
+
+Isso evita usuários sem formulário default.
+
+### Criação e Edição de Anamnese
+
+Arquivo alterado:
+
+`src/server/services/anamnesis.service.ts`
+
+Novo comportamento:
+
+1. Se `templateId` vier no input, valida ownership do template.
+2. Se `templateId` não vier, busca/cria o template padrão do médico.
+3. Salva `templateId` na anamnese.
+4. Filtra `customResponses` para remover qualquer chave que seja campo do sistema.
+5. Salva apenas campos realmente personalizados em `customResponses`.
+
+Isso impede que campos customizados sobrescrevam dados críticos do schema fixo.
+
+## Fluxo Manual de Anamnese
+
+Arquivos principais:
+
+- `src/features/anamnesis/hooks/use-anamnesis-form.tsx`
+- `src/features/anamnesis/components/anamnesis-wizard.tsx`
+- `src/features/anamnesis/components/dynamic-section-renderer.tsx`
+- `src/features/anamnesis/components/dynamic-field-renderer.tsx`
+- `src/features/anamnesis/components/review-step.tsx`
+
+### Fluxo
+
+1. A tela de nova anamnese busca `formTemplate.getDefault`.
+2. A primeira etapa continua sendo `Dados do Paciente`.
+3. As etapas clínicas passam a ser geradas a partir de `template.sections`.
+4. Cada seção renderiza seus campos com `DynamicSectionRenderer`.
+5. Cada campo é renderizado por `DynamicFieldRenderer`, conforme `fieldType`.
+6. Campos do sistema continuam escrevendo em `formData`.
+7. Campos customizados escrevem em `customValues`.
+8. No submit final, a anamnese envia:
+
+```ts
+{
+  templateId: defaultTemplate.id,
+  customResponses: customValues,
+  ...camposSistema
+}
+```
+
+### Renderização dinâmica
+
+`DynamicFieldRenderer` suporta:
+
+- textarea
+- input curto
+- número com unidade
+- checkbox
+- select
+- radio
+- date
+- NYHA
+- editor de medicamentos
+
+Enquanto o template carrega, as telas antigas continuam servindo como fallback.
+
+## Fluxo de Áudio
+
+Arquivos principais:
+
+- `src/schemas/audio-anamnesis-form.ts`
+- `src/server/services/audio/services/session.service.ts`
+- `src/server/services/audio/services/worker.service.ts`
+- `src/features/audio-anamnesis/components/audio-anamnesis-page.tsx`
+- `src/features/audio-anamnesis/components/audio-anamnesis-form.tsx`
+
+### Início da sessão
+
+Em `startSession`:
+
+1. O paciente é validado.
+2. O saldo de créditos é validado.
+3. O template padrão do médico é buscado/criado.
+4. `buildEmptyConsolidatedFormState` inicializa:
+
+```ts
+{
+  patient,
+  anamnesis,
+  customFields,
+  templateId
+}
+```
+
+`customFields` recebe as chaves dos campos personalizados do template.
+
+### Processamento pelo worker
+
+Em `worker.service.ts`:
+
+1. O worker carrega o `currentFormState`.
+2. Busca o template pelo `templateId` do estado.
+3. Gera uma descrição dinâmica do schema esperado.
+4. Inclui no prompt os campos customizados disponíveis.
+5. O LLM retorna `nextFormState` com:
+
+```ts
+{
+  patient,
+  anamnesis,
+  customFields,
+  templateId
+}
+```
+
+### Finalização da sessão
+
+Em `finalizeSession`:
+
+1. O estado consolidado é convertido para `CreateAnamnesisInput`.
+2. Campos sistema vão para colunas/tabelas existentes.
+3. `customFields` vira `customResponses`.
+4. `templateId` é salvo na anamnese.
+
+## Editor de Templates
+
+Rotas criadas:
+
+- `src/app/(main)/configuracoes/formularios/page.tsx`
+- `src/app/(main)/configuracoes/formularios/[templateId]/page.tsx`
+
+Feature criada:
+
+`src/features/form-template-editor/`
+
+Arquivos principais:
+
+- `components/template-list-page.tsx`
+- `components/template-editor-page.tsx`
+- `constants/field-type-meta.ts`
+- `types/editor.types.ts`
+
+### Tela de Lista
+
+Permite:
+
+- listar templates ativos
+- ver qual é o padrão
+- definir padrão
+- duplicar template
+- arquivar template não padrão
+- abrir editor
+
+### Tela de Editor
+
+Permite:
+
+- editar nome e descrição do template
+- marcar como default
+- editar seções
+- adicionar seções
+- reordenar seções com botões
+- editar campos
+- adicionar campos customizados
+- reordenar campos com botões
+- ocultar/mostrar campos
+- configurar obrigatoriedade
+- configurar tipo de campo
+- configurar unidade para campos numéricos
+- configurar opções para `SELECT` e `RADIO`
+
+Observação: a primeira versão usa botões de subir/descer para reordenação. A estrutura local já deixa o caminho aberto para trocar por drag-and-drop depois.
+
+## Sidebar
+
+Arquivo alterado:
+
+`src/features/layout/constants/sidebarItems.ts`
+
+`Configurações` virou grupo e ganhou:
+
+- `Minha Conta`
+- `Formulários`
+
+## Visualização de Anamneses
+
+Arquivos alterados:
+
+- `src/server/services/patient.service.ts`
+- `src/features/patients/components/anamnesis-detail-dialog.tsx`
+- `src/features/patients/components/anamnesis-detail-page.tsx`
+
+As queries de paciente agora incluem o template da anamnese com seções e campos.
+
+As telas de detalhe passam a renderizar campos personalizados em uma seção `Campos Personalizados`.
+
+Durante edição:
+
+- campos sistema continuam no fluxo existente.
+- campos customizados usam `DynamicFieldRenderer`.
+- ao salvar, `customResponses` é enviado para `anamnesis.update`.
+
+## Migração de Dados
+
+Foi adicionado:
+
+`scripts/seed-default-templates.ts`
+
+Esse script:
+
+1. Busca todos os perfis.
+2. Cria o template padrão para cada perfil, se ainda não existir.
+3. Associa anamneses antigas sem `templateId` ao template padrão do médico.
+
+Uso esperado:
+
+```bash
+npx tsx scripts/seed-default-templates.ts
+```
+
+Se o projeto não tiver `tsx` instalado, rode com o runner TypeScript adotado no ambiente ou adapte para o fluxo de scripts do deploy.
+
+## Compatibilidade Retroativa
+
+Anamneses antigas podem existir sem `templateId` até a execução do script de seed.
+
+O sistema foi preparado para:
+
+- criar template default automaticamente para perfis existentes quando acessados.
+- continuar mostrando campos sistema existentes.
+- associar anamneses antigas via script.
+
+## Validações e Garantias
+
+O que está protegido no backend:
+
+- ownership do template por `profileId`.
+- campos sistema não podem ser removidos.
+- campos sistema não podem trocar de tipo.
+- `customResponses` não aceita sobrescrever chaves de campos sistema.
+- templates arquivados não podem virar default.
+- template default anterior é desmarcado em transação.
+
+## Arquivos Criados
+
+- `prisma/schema/form-template.prisma`
+- `prisma/migrations/20260524123000_anamnesis_form_templates/migration.sql`
+- `scripts/seed-default-templates.ts`
+- `src/schemas/form-template.ts`
+- `src/server/services/formTemplate.service.ts`
+- `src/server/api/routers/formTemplate.router.ts`
+- `src/features/anamnesis/components/dynamic-field-renderer.tsx`
+- `src/features/anamnesis/components/dynamic-section-renderer.tsx`
+- `src/features/anamnesis/constants/system-fields.ts`
+- `src/features/form-template-editor/components/template-list-page.tsx`
+- `src/features/form-template-editor/components/template-editor-page.tsx`
+- `src/features/form-template-editor/constants/field-type-meta.ts`
+- `src/features/form-template-editor/types/editor.types.ts`
+- `src/app/(main)/configuracoes/formularios/page.tsx`
+- `src/app/(main)/configuracoes/formularios/[templateId]/page.tsx`
+
+## Arquivos Alterados
+
+Principais:
+
+- `prisma/schema/clinical.prisma`
+- `prisma/schema/users.prisma`
+- `src/schemas/anamnesis.ts`
+- `src/schemas/audio-anamnesis-form.ts`
+- `src/server/api/root.ts`
+- `src/server/services/anamnesis.service.ts`
+- `src/server/services/profile.service.ts`
+- `src/server/services/patient.service.ts`
+- `src/server/services/audio/services/session.service.ts`
+- `src/server/services/audio/services/worker.service.ts`
+- `src/features/anamnesis/hooks/use-anamnesis-form.tsx`
+- `src/features/anamnesis/components/anamnesis-wizard.tsx`
+- `src/features/anamnesis/components/review-step.tsx`
+- `src/features/audio-anamnesis/components/audio-anamnesis-page.tsx`
+- `src/features/audio-anamnesis/components/audio-anamnesis-form.tsx`
+- `src/features/patients/components/anamnesis-detail-dialog.tsx`
+- `src/features/patients/components/anamnesis-detail-page.tsx`
+- `src/features/layout/constants/sidebarItems.ts`
+
+Também houve pequenos ajustes de typecheck em:
+
+- `scripts/copy-vad-assets.js`
+- `src/features/create-schedule-consultation/types/schedule-consultation.types.ts`
+- `src/features/list-schedule-consultation/types/consultation.types.ts`
+
+## Validação Executada
+
+Foi executado:
+
+```bash
+npx prisma generate
+npm run typecheck
+```
+
+Ambos passaram.
+
+Também foi executado:
+
+```bash
+npm run lint
+```
+
+O lint ainda falhou por problemas já existentes fora do escopo principal da feature, em arquivos como:
+
+- `src/components/ui/progress.tsx`
+- `src/components/ui/textarea.tsx`
+- hooks/utilitários do módulo de áudio
+- `src/server/services/aiDiagnosis/index.ts`
+
+## Pontos Pendentes / Próximos Passos
+
+Melhorias naturais para uma próxima etapa:
+
+- trocar os botões de reordenação do editor por drag-and-drop com `@dnd-kit`.
+- adicionar preview lado a lado no editor.
+- adicionar criação de template vazio, além de duplicar o template padrão.
+- versionar templates para preservar exatamente a estrutura histórica usada por uma anamnese antiga.
+- melhorar validação por tipo de campo em `customResponses`.
+- rodar o script de seed em ambiente de staging/produção depois da migration.

--- a/prisma/migrations/20260524123000_anamnesis_form_templates/migration.sql
+++ b/prisma/migrations/20260524123000_anamnesis_form_templates/migration.sql
@@ -1,0 +1,88 @@
+-- CreateEnum
+CREATE TYPE "form_field_type" AS ENUM (
+    'TEXT',
+    'SHORT_TEXT',
+    'NUMBER',
+    'BOOLEAN',
+    'SELECT',
+    'RADIO',
+    'DATE',
+    'NYHA_CLASS',
+    'MEDICATIONS'
+);
+
+-- CreateTable
+CREATE TABLE "anamnesis_form_template" (
+    "id" TEXT NOT NULL,
+    "profile_id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "is_default" BOOLEAN NOT NULL DEFAULT false,
+    "is_archived" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "anamnesis_form_template_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "anamnesis_form_section" (
+    "id" TEXT NOT NULL,
+    "template_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "order" INTEGER NOT NULL,
+    "is_collapsible" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "anamnesis_form_section_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "anamnesis_form_field" (
+    "id" TEXT NOT NULL,
+    "section_id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "description" TEXT,
+    "order" INTEGER NOT NULL,
+    "field_type" "form_field_type" NOT NULL,
+    "is_required" BOOLEAN NOT NULL DEFAULT false,
+    "is_visible" BOOLEAN NOT NULL DEFAULT true,
+    "config" JSONB,
+    "is_system_field" BOOLEAN NOT NULL DEFAULT false,
+    "system_key" TEXT,
+
+    CONSTRAINT "anamnesis_form_field_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "Anamnesis"
+ADD COLUMN "templateId" TEXT,
+ADD COLUMN "customResponses" JSONB NOT NULL DEFAULT '{}';
+
+-- CreateIndex
+CREATE INDEX "anamnesis_form_template_profile_id_is_archived_idx" ON "anamnesis_form_template"("profile_id", "is_archived");
+
+-- CreateIndex
+CREATE INDEX "anamnesis_form_template_profile_id_is_default_idx" ON "anamnesis_form_template"("profile_id", "is_default");
+
+-- CreateIndex
+CREATE INDEX "anamnesis_form_section_template_id_order_idx" ON "anamnesis_form_section"("template_id", "order");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "anamnesis_form_field_section_id_key_key" ON "anamnesis_form_field"("section_id", "key");
+
+-- CreateIndex
+CREATE INDEX "anamnesis_form_field_section_id_order_idx" ON "anamnesis_form_field"("section_id", "order");
+
+-- AddForeignKey
+ALTER TABLE "anamnesis_form_template" ADD CONSTRAINT "anamnesis_form_template_profile_id_fkey" FOREIGN KEY ("profile_id") REFERENCES "profile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "anamnesis_form_section" ADD CONSTRAINT "anamnesis_form_section_template_id_fkey" FOREIGN KEY ("template_id") REFERENCES "anamnesis_form_template"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "anamnesis_form_field" ADD CONSTRAINT "anamnesis_form_field_section_id_fkey" FOREIGN KEY ("section_id") REFERENCES "anamnesis_form_section"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Anamnesis" ADD CONSTRAINT "Anamnesis_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "anamnesis_form_template"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema/clinical.prisma
+++ b/prisma/schema/clinical.prisma
@@ -69,7 +69,7 @@ model ScheduleConsultation {
   profileId String  @db.Uuid
   profile   Profile @relation(fields: [profileId], references: [id])
 
-  anamnesis Anamnesis?
+  anamnesis    Anamnesis?
   audioSession AudioConsultationSession?
 
   createdAt DateTime @default(now())
@@ -77,8 +77,8 @@ model ScheduleConsultation {
 }
 
 model Anamnesis {
-  id   String           @id @default(cuid())
-  date DateTime         @default(now())
+  id   String   @id @default(cuid())
+  date DateTime @default(now())
 
   patientId String
   patient   Patient @relation(fields: [patientId], references: [id])
@@ -98,8 +98,12 @@ model Anamnesis {
   hasEdema        Boolean   @default(false)
   hasChestPain    Boolean   @default(false)
 
-  consultationId String?       @unique
+  consultationId String?               @unique
   consultation   ScheduleConsultation? @relation(fields: [consultationId], references: [id])
+
+  templateId      String?
+  template        AnamnesisFormTemplate? @relation(fields: [templateId], references: [id], onDelete: SetNull)
+  customResponses Json                   @default("{}")
 
   physicalExam PhysicalExam?
   medications  PrescribedMedication[]
@@ -138,19 +142,19 @@ model PrescribedMedication {
 }
 
 model AiDiagnosis {
-  id          String   @id @default(cuid())
+  id          String    @id @default(cuid())
   patientId   String
-  patient     Patient  @relation(fields: [patientId], references: [id])
+  patient     Patient   @relation(fields: [patientId], references: [id])
   anamnesisId String
   anamnesis   Anamnesis @relation(fields: [anamnesisId], references: [id])
 
-  summary               String @db.Text
+  summary                 String @db.Text
   mainDiagnosisHypothesis String @db.Text
-  differentialDiagnoses  String @db.Text
-  identifiedPatterns     String @db.Text
-  riskAlerts             String @db.Text
-  recommendedActions     String @db.Text
-  confidenceLevel        String
+  differentialDiagnoses   String @db.Text
+  identifiedPatterns      String @db.Text
+  riskAlerts              String @db.Text
+  recommendedActions      String @db.Text
+  confidenceLevel         String
 
   isValid   Boolean  @default(true)
   createdAt DateTime @default(now())

--- a/prisma/schema/form-template.prisma
+++ b/prisma/schema/form-template.prisma
@@ -1,0 +1,77 @@
+enum FormFieldType {
+  TEXT
+  SHORT_TEXT
+  NUMBER
+  BOOLEAN
+  SELECT
+  RADIO
+  DATE
+  NYHA_CLASS
+  MEDICATIONS
+
+  @@map("form_field_type")
+}
+
+model AnamnesisFormTemplate {
+  id String @id @default(cuid())
+
+  profileId String  @map("profile_id") @db.Uuid
+  profile   Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)
+
+  name        String
+  description String? @db.Text
+  isDefault   Boolean @default(false) @map("is_default")
+  isArchived  Boolean @default(false) @map("is_archived")
+
+  sections  AnamnesisFormSection[]
+  anamneses Anamnesis[]
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+
+  @@index([profileId, isArchived])
+  @@index([profileId, isDefault])
+  @@map("anamnesis_form_template")
+}
+
+model AnamnesisFormSection {
+  id String @id @default(cuid())
+
+  templateId String                @map("template_id")
+  template   AnamnesisFormTemplate @relation(fields: [templateId], references: [id], onDelete: Cascade)
+
+  name          String
+  description   String? @db.Text
+  order         Int
+  isCollapsible Boolean @default(false) @map("is_collapsible")
+
+  fields AnamnesisFormField[]
+
+  @@index([templateId, order])
+  @@map("anamnesis_form_section")
+}
+
+model AnamnesisFormField {
+  id String @id @default(cuid())
+
+  sectionId String               @map("section_id")
+  section   AnamnesisFormSection @relation(fields: [sectionId], references: [id], onDelete: Cascade)
+
+  key         String
+  label       String
+  description String? @db.Text
+  order       Int
+
+  fieldType  FormFieldType @map("field_type")
+  isRequired Boolean       @default(false) @map("is_required")
+  isVisible  Boolean       @default(true) @map("is_visible")
+
+  config Json?
+
+  isSystemField Boolean @default(false) @map("is_system_field")
+  systemKey     String? @map("system_key")
+
+  @@unique([sectionId, key])
+  @@index([sectionId, order])
+  @@map("anamnesis_form_field")
+}

--- a/prisma/schema/users.prisma
+++ b/prisma/schema/users.prisma
@@ -6,6 +6,7 @@ model Profile {
   phone     String? @map("phone")
   photoUrl  String? @map("photo_url")
   addressId String? @unique @map("address_id") @db.Uuid
+  superAdmin Boolean @default(false) @map("super_admin")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
@@ -17,8 +18,9 @@ model Profile {
   patients      Patient[]
   anamneses     Anamnesis[]
   consultations ScheduleConsultation[]
+  formTemplates AnamnesisFormTemplate[]
 
-  audioSessions      AudioConsultationSession[]
+  audioSessions       AudioConsultationSession[]
   creditLedgerEntries CreditLedgerEntry[]
 
   @@map("profile")

--- a/scripts/seed-default-templates.ts
+++ b/scripts/seed-default-templates.ts
@@ -1,0 +1,25 @@
+import { db } from "../src/server/db";
+import { seedDefaultTemplate } from "../src/server/services/formTemplate.service";
+
+const main = async () => {
+  const profiles = await db.profile.findMany({ select: { id: true } });
+
+  for (const profile of profiles) {
+    const template = await seedDefaultTemplate(db, profile.id);
+    await db.anamnesis.updateMany({
+      where: { profileId: profile.id, templateId: null },
+      data: { templateId: template.id },
+    });
+  }
+
+  console.log(`Seeded default anamnesis templates for ${profiles.length} profiles.`);
+};
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });

--- a/src/app/(main)/configuracoes/formularios/[templateId]/page.tsx
+++ b/src/app/(main)/configuracoes/formularios/[templateId]/page.tsx
@@ -1,0 +1,14 @@
+import { TemplateEditorPage } from "~/features/form-template-editor/components/template-editor-page";
+
+type Props = {
+  params: Promise<{ templateId: string }>;
+};
+
+export const metadata = {
+  title: "Editor de Formulario | Care Copilot",
+};
+
+export default async function TemplateEditorRoute({ params }: Props) {
+  const { templateId } = await params;
+  return <TemplateEditorPage templateId={templateId} />;
+}

--- a/src/app/(main)/configuracoes/formularios/page.tsx
+++ b/src/app/(main)/configuracoes/formularios/page.tsx
@@ -1,0 +1,9 @@
+import { TemplateListPage } from "~/features/form-template-editor/components/template-list-page";
+
+export const metadata = {
+  title: "Formularios | Care Copilot",
+};
+
+export default function FormTemplatesPage() {
+  return <TemplateListPage />;
+}

--- a/src/features/anamnesis/components/anamnesis-wizard.tsx
+++ b/src/features/anamnesis/components/anamnesis-wizard.tsx
@@ -12,8 +12,7 @@ import { AnamnesisDataStep } from "~/features/anamnesis/components/anamnesis-dat
 import { PhysicalExamStep } from "~/features/anamnesis/components/physical-exam-step"
 import { DiagnosisStep } from "~/features/anamnesis/components/diagnosis-step"
 import { ReviewStep } from "~/features/anamnesis/components/review-step"
-
-import { steps } from "~/features/anamnesis/constants/steps"
+import { DynamicSectionRenderer } from "~/features/anamnesis/components/dynamic-section-renderer"
 
 
 export function AnamnesisWizard({ consultationId }: { consultationId?: string }) {
@@ -22,6 +21,10 @@ export function AnamnesisWizard({ consultationId }: { consultationId?: string })
     isLoading,
     formData,
     setFormData,
+    template,
+    steps,
+    customValues,
+    setCustomValues,
     selectedPatientId,
     medications,
     handleNext,
@@ -33,6 +36,9 @@ export function AnamnesisWizard({ consultationId }: { consultationId?: string })
     updateMedication,
     removeMedication,
   } = useAnamnesisForm({ consultationId })
+
+  const isFinalStep = currentStep === steps.length
+  const currentTemplateSection = template?.sections[currentStep - 2]
 
   return (
     <div className="min-h-screen bg-background p-4 md:p-8">
@@ -58,9 +64,22 @@ export function AnamnesisWizard({ consultationId }: { consultationId?: string })
                 onClearExistingPatient={handleClearExistingPatient}
               />
             )}
-            {currentStep === 2 && <AnamnesisDataStep formData={formData} setFormData={setFormData} />}
-            {currentStep === 3 && <PhysicalExamStep formData={formData} setFormData={setFormData} />}
-            {currentStep === 4 && (
+            {template && currentTemplateSection && !isFinalStep && (
+              <DynamicSectionRenderer
+                section={currentTemplateSection}
+                formData={formData}
+                setFormData={setFormData}
+                customValues={customValues}
+                setCustomValues={setCustomValues}
+                medications={medications}
+                addMedication={addMedication}
+                updateMedication={updateMedication}
+                removeMedication={removeMedication}
+              />
+            )}
+            {!template && currentStep === 2 && <AnamnesisDataStep formData={formData} setFormData={setFormData} />}
+            {!template && currentStep === 3 && <PhysicalExamStep formData={formData} setFormData={setFormData} />}
+            {!template && currentStep === 4 && (
               <DiagnosisStep
                 formData={formData}
                 setFormData={setFormData}
@@ -70,7 +89,14 @@ export function AnamnesisWizard({ consultationId }: { consultationId?: string })
                 removeMedication={removeMedication}
               />
             )}
-            {currentStep === 5 && <ReviewStep formData={formData} medications={medications} />}
+            {isFinalStep && (
+              <ReviewStep
+                formData={formData}
+                medications={medications}
+                template={template}
+                customValues={customValues}
+              />
+            )}
 
             <div className="flex justify-between pt-6 border-t">
               <Button
@@ -83,14 +109,14 @@ export function AnamnesisWizard({ consultationId }: { consultationId?: string })
                 Voltar
               </Button>
 
-              {currentStep < 5 ? (
+              {currentStep < steps.length ? (
                 <Button
                   type="button"
                   onClick={handleNext}
                   disabled={
                     isLoading ||
                     (currentStep === 1 && (!formData.name || !formData.birthDate || !formData.gender)) ||
-                    (currentStep === 2 &&
+                    (!template && currentStep === 2 &&
                       (!formData.chiefComplaint || !formData.currentIllnessHistory))
                   }
                 >

--- a/src/features/anamnesis/components/dynamic-field-renderer.tsx
+++ b/src/features/anamnesis/components/dynamic-field-renderer.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "~/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { Textarea } from "~/components/ui/textarea";
+import {
+  formFieldConfigSchema,
+  type FormFieldType,
+} from "~/schemas/form-template";
+
+type Medication = { name: string; dosage: string; frequency: string };
+
+export type DynamicField = {
+  key: string;
+  label: string;
+  description?: string | null;
+  fieldType: FormFieldType;
+  isRequired: boolean;
+  isVisible: boolean;
+  config?: unknown;
+};
+
+type Props = {
+  field: DynamicField;
+  value: unknown;
+  onChange: (value: unknown) => void;
+  medications?: Medication[];
+  addMedication?: () => void;
+  updateMedication?: (index: number, field: string, value: string) => void;
+  removeMedication?: (index: number) => void;
+  readOnly?: boolean;
+};
+
+const toDateInputValue = (value: unknown) => {
+  if (!value) return "";
+  if (
+    !(value instanceof Date) &&
+    typeof value !== "string" &&
+    typeof value !== "number"
+  ) {
+    return "";
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? "" : date.toISOString().split("T")[0]!;
+};
+
+const getConfig = (value: unknown) => {
+  const parsed = formFieldConfigSchema.safeParse(value ?? {});
+  return parsed.success ? parsed.data : {};
+};
+
+export function DynamicFieldRenderer({
+  field,
+  value,
+  onChange,
+  medications = [],
+  addMedication,
+  updateMedication,
+  removeMedication,
+  readOnly = false,
+}: Props) {
+  if (!field.isVisible) return null;
+
+  const config = getConfig(field.config);
+  const label = (
+    <Label htmlFor={field.key} className="mb-2 block">
+      {field.label}
+      {field.isRequired ? " *" : ""}
+    </Label>
+  );
+
+  if (field.fieldType === "MEDICATIONS") {
+    return (
+      <div className="space-y-3 border-t pt-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h3 className="font-medium">{field.label}</h3>
+            {field.description && (
+              <p className="text-sm text-muted-foreground">{field.description}</p>
+            )}
+          </div>
+          {!readOnly && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={addMedication}
+            >
+              <Plus className="h-4 w-4" />
+              Adicionar
+            </Button>
+          )}
+        </div>
+
+        {medications.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Nenhum medicamento adicionado
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {medications.map((med, index) => (
+              <div
+                key={index}
+                className="grid grid-cols-1 gap-3 rounded-lg border p-4 md:grid-cols-[1fr_1fr_1fr_auto]"
+              >
+                <Input
+                  value={med.name}
+                  onChange={(event) =>
+                    updateMedication?.(index, "name", event.target.value)
+                  }
+                  placeholder="Medicamento"
+                  readOnly={readOnly}
+                />
+                <Input
+                  value={med.dosage}
+                  onChange={(event) =>
+                    updateMedication?.(index, "dosage", event.target.value)
+                  }
+                  placeholder="Dosagem"
+                  readOnly={readOnly}
+                />
+                <Input
+                  value={med.frequency}
+                  onChange={(event) =>
+                    updateMedication?.(index, "frequency", event.target.value)
+                  }
+                  placeholder="Frequencia"
+                  readOnly={readOnly}
+                />
+                {!readOnly && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => removeMedication?.(index)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    <span className="sr-only">Remover medicamento</span>
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (field.fieldType === "BOOLEAN") {
+    return (
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id={field.key}
+          checked={Boolean(value)}
+          onCheckedChange={(checked) => onChange(Boolean(checked))}
+          disabled={readOnly}
+        />
+        <Label htmlFor={field.key} className="font-normal">
+          {field.label}
+        </Label>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {label}
+      {field.description && (
+        <p className="mb-2 text-sm text-muted-foreground">{field.description}</p>
+      )}
+
+      {field.fieldType === "TEXT" && (
+        <Textarea
+          id={field.key}
+          value={typeof value === "string" ? value : ""}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={config.placeholder}
+          maxLength={config.maxLength}
+          readOnly={readOnly}
+          rows={3}
+        />
+      )}
+
+      {field.fieldType === "SHORT_TEXT" && (
+        <Input
+          id={field.key}
+          value={typeof value === "string" ? value : ""}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={config.placeholder}
+          maxLength={config.maxLength}
+          readOnly={readOnly}
+        />
+      )}
+
+      {field.fieldType === "NUMBER" && (
+        <div className="flex items-center gap-2">
+          <Input
+            id={field.key}
+            type="number"
+            min={config.min}
+            max={config.max}
+            step={config.step ?? 1}
+            value={typeof value === "number" && !Number.isNaN(value) ? value : ""}
+            readOnly={readOnly}
+            onChange={(event) =>
+              onChange(
+                event.target.value === "" ? undefined : Number(event.target.value),
+              )
+            }
+          />
+          {config.unit && (
+            <span className="w-16 text-sm text-muted-foreground">
+              {config.unit}
+            </span>
+          )}
+        </div>
+      )}
+
+      {field.fieldType === "SELECT" && (
+        <Select
+          value={typeof value === "string" ? value : ""}
+          onValueChange={onChange}
+          disabled={readOnly}
+        >
+          <SelectTrigger id={field.key}>
+            <SelectValue placeholder={config.placeholder ?? "Selecione"} />
+          </SelectTrigger>
+          <SelectContent>
+            {(config.options ?? []).map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
+      {field.fieldType === "RADIO" && (
+        <RadioGroup
+          value={typeof value === "string" ? value : ""}
+          onValueChange={onChange}
+          disabled={readOnly}
+          className="grid grid-cols-1 gap-2 sm:grid-cols-2"
+        >
+          {(config.options ?? []).map((option) => (
+            <label
+              key={option.value}
+              className="flex items-center gap-2 rounded-md border p-3 text-sm"
+            >
+              <RadioGroupItem value={option.value} />
+              {option.label}
+            </label>
+          ))}
+        </RadioGroup>
+      )}
+
+      {field.fieldType === "DATE" && (
+        <Input
+          id={field.key}
+          type="date"
+          value={toDateInputValue(value)}
+          readOnly={readOnly}
+          onChange={(event) =>
+            onChange(event.target.value ? new Date(event.target.value) : undefined)
+          }
+        />
+      )}
+
+      {field.fieldType === "NYHA_CLASS" && (
+        <Select
+          value={typeof value === "string" ? value : "I"}
+          onValueChange={onChange}
+          disabled={readOnly}
+        >
+          <SelectTrigger id={field.key}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="I">Classe I</SelectItem>
+            <SelectItem value="II">Classe II</SelectItem>
+            <SelectItem value="III">Classe III</SelectItem>
+            <SelectItem value="IV">Classe IV</SelectItem>
+          </SelectContent>
+        </Select>
+      )}
+    </div>
+  );
+}

--- a/src/features/anamnesis/components/dynamic-section-renderer.tsx
+++ b/src/features/anamnesis/components/dynamic-section-renderer.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import type { FormData } from "~/features/anamnesis/hooks/use-anamnesis-form";
+import { PHYSICAL_EXAM_FIELD_KEYS } from "~/features/anamnesis/constants/system-fields";
+import {
+  DynamicFieldRenderer,
+  type DynamicField,
+} from "~/features/anamnesis/components/dynamic-field-renderer";
+import type { FormFieldType } from "~/schemas/form-template";
+
+type TemplateSection = {
+  id: string;
+  fields: Array<DynamicField & {
+    id: string;
+    systemKey?: string | null;
+    isSystemField: boolean;
+    fieldType: FormFieldType;
+  }>;
+};
+
+type Medication = { name: string; dosage: string; frequency: string };
+
+type Props = {
+  section: TemplateSection;
+  formData: Partial<FormData>;
+  setFormData: (data: Partial<FormData>) => void;
+  customValues: Record<string, unknown>;
+  setCustomValues: (data: Record<string, unknown>) => void;
+  medications: Medication[];
+  addMedication: () => void;
+  updateMedication: (index: number, field: string, value: string) => void;
+  removeMedication: (index: number) => void;
+  readOnly?: boolean;
+};
+
+const getSystemValue = (formData: Partial<FormData>, key: string) => {
+  if (PHYSICAL_EXAM_FIELD_KEYS.has(key)) {
+    return formData.physicalExam?.[
+      key as keyof NonNullable<FormData["physicalExam"]>
+    ];
+  }
+
+  return formData[key as keyof FormData];
+};
+
+const setSystemValue = (
+  formData: Partial<FormData>,
+  setFormData: (data: Partial<FormData>) => void,
+  key: string,
+  value: unknown,
+) => {
+  if (PHYSICAL_EXAM_FIELD_KEYS.has(key)) {
+    setFormData({
+      ...formData,
+      physicalExam: {
+        ...formData.physicalExam,
+        [key]: value,
+      },
+    });
+    return;
+  }
+
+  setFormData({
+    ...formData,
+    [key]: value,
+  });
+};
+
+export function DynamicSectionRenderer({
+  section,
+  formData,
+  setFormData,
+  customValues,
+  setCustomValues,
+  medications,
+  addMedication,
+  updateMedication,
+  removeMedication,
+  readOnly = false,
+}: Props) {
+  return (
+    <div className="space-y-6">
+      {section.fields
+        .filter((field) => field.isVisible)
+        .map((field) => {
+          const systemKey = field.systemKey ?? field.key;
+          const isSystemField = field.isSystemField;
+
+          return (
+            <DynamicFieldRenderer
+              key={field.id}
+              field={field}
+              value={
+                isSystemField
+                  ? getSystemValue(formData, systemKey)
+                  : customValues[field.key]
+              }
+              onChange={(value) => {
+                if (isSystemField) {
+                  setSystemValue(formData, setFormData, systemKey, value);
+                  return;
+                }
+
+                setCustomValues({
+                  ...customValues,
+                  [field.key]: value,
+                });
+              }}
+              medications={medications}
+              addMedication={addMedication}
+              updateMedication={updateMedication}
+              removeMedication={removeMedication}
+              readOnly={readOnly}
+            />
+          );
+        })}
+    </div>
+  );
+}

--- a/src/features/anamnesis/components/review-step.tsx
+++ b/src/features/anamnesis/components/review-step.tsx
@@ -3,9 +3,41 @@ import type { FormData } from "~/features/anamnesis/hooks/use-anamnesis-form"
 type ReviewStepProps = {
   formData: Partial<FormData>
   medications: Array<{ name: string; dosage: string; frequency: string }>
+  template?: {
+    sections: Array<{
+      fields: Array<{
+        key: string
+        label: string
+        isSystemField: boolean
+        isVisible: boolean
+      }>
+    }>
+  }
+  customValues?: Record<string, unknown>
 }
 
-export function ReviewStep({ formData, medications }: ReviewStepProps) {
+const formatCustomValue = (value: unknown) => {
+  if (value == null || value === "") return "Nao informado"
+  if (value instanceof Date) return value.toLocaleDateString("pt-BR")
+  if (typeof value === "string") return value
+  if (typeof value === "number") return String(value)
+  if (typeof value === "boolean") return value ? "Sim" : "Nao"
+  if (Array.isArray(value)) return value.join(", ")
+  if (typeof value === "object") return JSON.stringify(value)
+  return "Nao informado"
+}
+
+export function ReviewStep({
+  formData,
+  medications,
+  template,
+  customValues = {},
+}: ReviewStepProps) {
+  const customFields =
+    template?.sections.flatMap((section) =>
+      section.fields.filter((field) => !field.isSystemField && field.isVisible),
+    ) ?? []
+
   return (
     <div className="space-y-6">
       <div className="bg-muted/50 p-4 rounded-lg">
@@ -110,6 +142,22 @@ export function ReviewStep({ formData, medications }: ReviewStepProps) {
         <div className="bg-muted/50 p-4 rounded-lg">
           <h3 className="font-medium mb-3">Conduta</h3>
           <p className="text-sm">{formData.conduct}</p>
+        </div>
+      )}
+
+      {customFields.length > 0 && (
+        <div className="bg-muted/50 p-4 rounded-lg">
+          <h3 className="font-medium mb-3">Campos personalizados</h3>
+          <div className="space-y-2 text-sm">
+            {customFields.map((field) => (
+              <div key={field.key} className="grid grid-cols-3 gap-2">
+                <span className="text-muted-foreground">{field.label}:</span>
+                <span className="col-span-2">
+                  {formatCustomValue(customValues[field.key])}
+                </span>
+              </div>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/src/features/anamnesis/constants/system-fields.ts
+++ b/src/features/anamnesis/constants/system-fields.ts
@@ -1,0 +1,30 @@
+export const PHYSICAL_EXAM_FIELD_KEYS = new Set([
+  "weight",
+  "height",
+  "bpSystolic",
+  "bpDiastolic",
+  "heartRate",
+  "oxygenSaturation",
+  "heartAuscultation",
+  "lungAuscultation",
+  "peripheralPulses",
+  "edemaGrade",
+]);
+
+export const SYSTEM_FIELD_KEYS = new Set([
+  "chiefComplaint",
+  "currentIllnessHistory",
+  "treatmentResponse",
+  "symptomEvolution",
+  "newEvents",
+  "nyhaClass",
+  "hasPalpitations",
+  "hasSyncope",
+  "hasEdema",
+  "hasChestPain",
+  "medications",
+  "diagnosticHypothesis",
+  "conduct",
+  "nextRecallDate",
+  ...PHYSICAL_EXAM_FIELD_KEYS,
+]);

--- a/src/features/anamnesis/hooks/use-anamnesis-form.tsx
+++ b/src/features/anamnesis/hooks/use-anamnesis-form.tsx
@@ -1,11 +1,13 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { toast } from "sonner"
 import { api } from "~/trpc/react"
 import { type CreatePatientInput } from "~/schemas/patient"
 import { type CreateAnamnesisInput } from "~/schemas/anamnesis"
 import { useRouter } from "next/navigation"
+import { steps as DEFAULT_STEPS } from "~/features/anamnesis/constants/steps"
+import { PHYSICAL_EXAM_FIELD_KEYS } from "~/features/anamnesis/constants/system-fields"
 
 export type FormData = {
   name: string
@@ -57,6 +59,29 @@ type UseAnamnesisFormOptions = {
   consultationId?: string
 }
 
+const getSystemValue = (formData: Partial<FormData>, key: string) => {
+  if (PHYSICAL_EXAM_FIELD_KEYS.has(key)) {
+    return formData.physicalExam?.[
+      key as keyof NonNullable<FormData["physicalExam"]>
+    ]
+  }
+
+  return formData[key as keyof FormData]
+}
+
+const isEmptyRequiredValue = (value: unknown) => {
+  if (value == null) return true
+  if (typeof value === "string") return value.trim().length === 0
+  if (Array.isArray(value)) return value.length === 0
+  return false
+}
+
+const cleanOptionalString = (value?: string) => {
+  const trimmed = value?.trim()
+  if (!trimmed) return undefined
+  return trimmed
+}
+
 export function useAnamnesisForm(opts: UseAnamnesisFormOptions = {}) {
   const router = useRouter();
 
@@ -73,6 +98,10 @@ export function useAnamnesisForm(opts: UseAnamnesisFormOptions = {}) {
   })
 
   const [medications, setMedications] = useState<Array<{ name: string; dosage: string; frequency: string }>>([])
+  const [customValues, setCustomValues] = useState<Record<string, unknown>>({})
+
+  const { data: defaultTemplate, isLoading: isLoadingTemplate } =
+    api.formTemplate.getDefault.useQuery()
 
   const { data: consultation, isLoading: isLoadingConsultation } = api.scheduleConsultation.getById.useQuery(
     { id: opts.consultationId! },
@@ -123,7 +152,28 @@ export function useAnamnesisForm(opts: UseAnamnesisFormOptions = {}) {
     }
   })
 
-  const isLoading = createPatientMutation.isPending || createAnamnesisMutation.isPending || isLoadingConsultation
+  const steps = useMemo(() => {
+    if (!defaultTemplate) return DEFAULT_STEPS
+
+    return [
+      { number: 1, title: "Dados do Paciente" },
+      ...defaultTemplate.sections.map((section, index) => ({
+        number: index + 2,
+        title: section.name,
+        sectionId: section.id,
+      })),
+      {
+        number: defaultTemplate.sections.length + 2,
+        title: "Revisão Final",
+      },
+    ]
+  }, [defaultTemplate])
+
+  const isLoading =
+    createPatientMutation.isPending ||
+    createAnamnesisMutation.isPending ||
+    isLoadingConsultation ||
+    isLoadingTemplate
 
   const handleSelectExistingPatient = (id: string) => {
     setSelectedPatientId(id)
@@ -158,12 +208,31 @@ export function useAnamnesisForm(opts: UseAnamnesisFormOptions = {}) {
         name: formData.name,
         birthDate: formData.birthDate,
         gender: genderMap[formData.gender] ?? "Outro",
-        cpf: formData.cpf || undefined,
+        cpf: cleanOptionalString(formData.cpf),
         clinicalProfile: formData.clinicalProfile,
       }
 
       createPatientMutation.mutate(patientData)
       return
+    }
+
+    if (defaultTemplate && currentStep > 1 && currentStep < steps.length) {
+      const section = defaultTemplate.sections[currentStep - 2]
+      const missingField = section?.fields
+        .filter((field) => field.isVisible && field.isRequired)
+        .find((field) => {
+          const key = field.systemKey ?? field.key
+          const value = field.isSystemField
+            ? getSystemValue(formData, key)
+            : customValues[field.key]
+
+          return isEmptyRequiredValue(value)
+        })
+
+      if (missingField) {
+        toast.error(`Preencha o campo obrigatório: ${missingField.label}.`)
+        return
+      }
     }
 
     setCurrentStep(currentStep + 1)
@@ -206,6 +275,8 @@ export function useAnamnesisForm(opts: UseAnamnesisFormOptions = {}) {
       diagnosticHypothesis: formData.diagnosticHypothesis,
       conduct: formData.conduct,
       nextRecallDate: formData.nextRecallDate,
+      templateId: defaultTemplate?.id,
+      customResponses: customValues,
     }
 
     createAnamnesisMutation.mutate(anamnesisData)
@@ -235,6 +306,10 @@ export function useAnamnesisForm(opts: UseAnamnesisFormOptions = {}) {
     isLoading,
     formData,
     setFormData,
+    template: defaultTemplate,
+    steps,
+    customValues,
+    setCustomValues,
     medications,
     handleNext,
     handlePrevious,

--- a/src/features/audio-anamnesis/components/audio-anamnesis-form.tsx
+++ b/src/features/audio-anamnesis/components/audio-anamnesis-form.tsx
@@ -5,16 +5,50 @@ import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { Textarea } from "~/components/ui/textarea";
 import type { ConsolidatedFormState } from "~/schemas/audio-anamnesis-form";
+import { DynamicFieldRenderer } from "~/features/anamnesis/components/dynamic-field-renderer";
+import { PHYSICAL_EXAM_FIELD_KEYS } from "~/features/anamnesis/constants/system-fields";
+import type { FormFieldType } from "~/schemas/form-template";
 
 type Props = {
   formState: ConsolidatedFormState;
+  template?: {
+    sections: Array<{
+      id: string;
+      name: string;
+      fields: Array<{
+        id: string;
+        key: string;
+        label: string;
+        description?: string | null;
+        fieldType: FormFieldType;
+        isRequired: boolean;
+        isVisible: boolean;
+        config?: unknown;
+        isSystemField: boolean;
+        systemKey?: string | null;
+      }>;
+    }>;
+  };
   readOnly?: boolean;
 };
 
 const yesNo = (v: boolean | null | undefined) =>
   v === true ? "Sim" : v === false ? "Nao" : "-";
 
-export function AudioAnamnesisForm({ formState, readOnly }: Props) {
+const getAudioSystemValue = (
+  anamnesis: ConsolidatedFormState["anamnesis"],
+  key: string,
+) => {
+  if (PHYSICAL_EXAM_FIELD_KEYS.has(key)) {
+    return anamnesis.physicalExam[
+      key as keyof ConsolidatedFormState["anamnesis"]["physicalExam"]
+    ];
+  }
+
+  return anamnesis[key as keyof ConsolidatedFormState["anamnesis"]];
+};
+
+export function AudioAnamnesisForm({ formState, template, readOnly }: Props) {
   const p = formState.patient;
   const cp = p.clinicalProfile;
   const a = formState.anamnesis;
@@ -66,6 +100,34 @@ export function AudioAnamnesisForm({ formState, readOnly }: Props) {
         </CardContent>
       </Card>
 
+      {template ? (
+        template.sections.map((section) => (
+          <Card key={section.id}>
+            <CardHeader>
+              <CardTitle>{section.name}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {section.fields
+                .filter((field) => field.isVisible)
+                .map((field) => (
+                  <DynamicFieldRenderer
+                    key={field.id}
+                    field={field}
+                    value={
+                      field.isSystemField
+                        ? getAudioSystemValue(a, field.systemKey ?? field.key)
+                        : formState.customFields[field.key]
+                    }
+                    onChange={() => undefined}
+                    medications={a.medications}
+                    readOnly
+                  />
+                ))}
+            </CardContent>
+          </Card>
+        ))
+      ) : (
+        <>
       <Card>
         <CardHeader>
           <CardTitle>Anamnese</CardTitle>
@@ -172,6 +234,8 @@ export function AudioAnamnesisForm({ formState, readOnly }: Props) {
           />
         </CardContent>
       </Card>
+        </>
+      )}
 
       {readOnly && (
         <p className="text-xs text-muted-foreground">

--- a/src/features/form-template-editor/components/template-editor-page.tsx
+++ b/src/features/form-template-editor/components/template-editor-page.tsx
@@ -1,0 +1,572 @@
+"use client";
+
+import { ArrowDown, ArrowLeft, ArrowUp, Eye, EyeOff, Plus, Save, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { Switch } from "~/components/ui/switch";
+import { Textarea } from "~/components/ui/textarea";
+import { FIELD_TYPE_META, FIELD_TYPE_OPTIONS } from "~/features/form-template-editor/constants/field-type-meta";
+import type { EditorField, EditorSection, EditorState } from "~/features/form-template-editor/types/editor.types";
+import type { FormFieldConfig, FormFieldType } from "~/schemas/form-template";
+import { api } from "~/trpc/react";
+import type { RouterOutputs } from "~/trpc/react";
+
+type Props = {
+  templateId: string;
+};
+
+const tempId = () => crypto.randomUUID();
+
+const buildField = (order: number): EditorField => ({
+  key: `custom_${Date.now()}`,
+  label: "Novo campo",
+  order,
+  fieldType: "TEXT",
+  isRequired: false,
+  isVisible: true,
+  isSystemField: false,
+  config: {},
+  tempId: tempId(),
+});
+
+const sortByOrder = <T extends { order: number }>(items: T[]) =>
+  [...items].sort((a, b) => a.order - b.order);
+
+type TemplateOutput = RouterOutputs["formTemplate"]["getById"];
+
+const transformTemplate = (template: TemplateOutput): EditorState => ({
+  id: template.id,
+  name: template.name,
+  description: template.description,
+  isDefault: template.isDefault,
+  sections: sortByOrder(template.sections).map((section) => ({
+    id: section.id,
+    name: section.name,
+    description: section.description,
+    order: section.order,
+    isCollapsible: section.isCollapsible,
+    tempId: section.id,
+    fields: sortByOrder(section.fields).map((field) => ({
+      id: field.id,
+      key: field.key,
+      label: field.label,
+      description: field.description,
+      order: field.order,
+      fieldType: field.fieldType,
+      isRequired: field.isRequired,
+      isVisible: field.isVisible,
+      isSystemField: field.isSystemField,
+      systemKey: field.systemKey,
+      config: (field.config ?? {}) as FormFieldConfig,
+      tempId: field.id,
+    })),
+  })),
+});
+
+const renumberSections = (sections: EditorSection[]) =>
+  sections.map((section, index) => ({
+    ...section,
+    order: index,
+    fields: section.fields.map((field, fieldIndex) => ({
+      ...field,
+      order: fieldIndex,
+    })),
+  }));
+
+export function TemplateEditorPage({ templateId }: Props) {
+  const router = useRouter();
+  const utils = api.useUtils();
+  const template = api.formTemplate.getById.useQuery({ id: templateId });
+  const [editor, setEditor] = useState<EditorState | null>(null);
+
+  useEffect(() => {
+    if (template.data) setEditor(transformTemplate(template.data));
+  }, [template.data]);
+
+  const update = api.formTemplate.update.useMutation({
+    onSuccess: async (saved) => {
+      await utils.formTemplate.list.invalidate();
+      await utils.formTemplate.getById.invalidate({ id: saved.id });
+      toast.success("Template salvo");
+      setEditor(transformTemplate(saved));
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const visibleFieldCount = useMemo(
+    () =>
+      editor?.sections.reduce(
+        (total, section) =>
+          total + section.fields.filter((field) => field.isVisible).length,
+        0,
+      ) ?? 0,
+    [editor],
+  );
+
+  if (template.isLoading || !editor) {
+    return (
+      <div className="min-h-screen bg-background p-4 md:p-8">
+        <div className="mx-auto max-w-5xl">
+          <Card>
+            <CardContent className="py-10 text-center text-sm text-muted-foreground">
+              Carregando editor...
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  const setSection = (sectionIndex: number, patch: Partial<EditorSection>) => {
+    setEditor((prev) =>
+      prev
+        ? {
+            ...prev,
+            sections: prev.sections.map((section, index) =>
+              index === sectionIndex ? { ...section, ...patch } : section,
+            ),
+          }
+        : prev,
+    );
+  };
+
+  const setField = (
+    sectionIndex: number,
+    fieldIndex: number,
+    patch: Partial<EditorField>,
+  ) => {
+    setEditor((prev) =>
+      prev
+        ? {
+            ...prev,
+            sections: prev.sections.map((section, index) =>
+              index === sectionIndex
+                ? {
+                    ...section,
+                    fields: section.fields.map((field, currentFieldIndex) =>
+                      currentFieldIndex === fieldIndex
+                        ? { ...field, ...patch }
+                        : field,
+                    ),
+                  }
+                : section,
+            ),
+          }
+        : prev,
+    );
+  };
+
+  const moveSection = (sectionIndex: number, direction: -1 | 1) => {
+    const target = sectionIndex + direction;
+    if (target < 0 || target >= editor.sections.length) return;
+    const sections = [...editor.sections];
+    const [section] = sections.splice(sectionIndex, 1);
+    if (!section) return;
+    sections.splice(target, 0, section);
+    setEditor({ ...editor, sections: renumberSections(sections) });
+  };
+
+  const moveField = (sectionIndex: number, fieldIndex: number, direction: -1 | 1) => {
+    const section = editor.sections[sectionIndex];
+    if (!section) return;
+    const target = fieldIndex + direction;
+    if (target < 0 || target >= section.fields.length) return;
+    const fields = [...section.fields];
+    const [field] = fields.splice(fieldIndex, 1);
+    if (!field) return;
+    fields.splice(target, 0, field);
+    setSection(sectionIndex, {
+      fields: fields.map((item, index) => ({ ...item, order: index })),
+    });
+  };
+
+  const save = () => {
+    update.mutate({
+      id: editor.id,
+      name: editor.name,
+      description: editor.description,
+      isDefault: editor.isDefault,
+      sections: renumberSections(editor.sections).map((section) => ({
+        id: section.id,
+        name: section.name,
+        description: section.description,
+        order: section.order,
+        isCollapsible: section.isCollapsible,
+        fields: section.fields.map((field) => ({
+          id: field.id,
+          key: field.key,
+          label: field.label,
+          description: field.description,
+          order: field.order,
+          fieldType: field.fieldType,
+          isRequired: field.isRequired,
+          isVisible: field.isVisible,
+          isSystemField: field.isSystemField,
+          systemKey: field.systemKey,
+          config: field.config,
+        })),
+      })),
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-background p-4 md:p-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" size="icon" onClick={() => router.back()}>
+              <ArrowLeft className="h-4 w-4" />
+              <span className="sr-only">Voltar</span>
+            </Button>
+            <div>
+              <h1 className="text-3xl font-semibold">Editor de formulario</h1>
+              <p className="text-muted-foreground">
+                {editor.sections.length} secoes, {visibleFieldCount} campos visiveis
+              </p>
+            </div>
+          </div>
+          <Button onClick={save} disabled={update.isPending}>
+            <Save className="h-4 w-4" />
+            {update.isPending ? "Salvando..." : "Salvar"}
+          </Button>
+        </div>
+
+        <Card>
+          <CardContent className="grid gap-4 pt-6 md:grid-cols-[1fr_2fr_auto]">
+            <div>
+              <Label htmlFor="template-name" className="mb-2 block">
+                Nome
+              </Label>
+              <Input
+                id="template-name"
+                value={editor.name}
+                onChange={(event) =>
+                  setEditor({ ...editor, name: event.target.value })
+                }
+              />
+            </div>
+            <div>
+              <Label htmlFor="template-description" className="mb-2 block">
+                Descricao
+              </Label>
+              <Input
+                id="template-description"
+                value={editor.description ?? ""}
+                onChange={(event) =>
+                  setEditor({ ...editor, description: event.target.value })
+                }
+              />
+            </div>
+            <label className="flex items-center gap-2 self-end rounded-md border px-3 py-2 text-sm">
+              <Switch
+                checked={editor.isDefault}
+                onCheckedChange={(checked) =>
+                  setEditor({ ...editor, isDefault: checked })
+                }
+              />
+              Padrao
+            </label>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-4">
+          {editor.sections.map((section, sectionIndex) => (
+            <Card key={section.tempId}>
+              <CardHeader className="gap-4 md:grid-cols-[1fr_auto]">
+                <div className="grid gap-3 md:grid-cols-2">
+                  <Input
+                    value={section.name}
+                    onChange={(event) =>
+                      setSection(sectionIndex, { name: event.target.value })
+                    }
+                    aria-label="Nome da secao"
+                  />
+                  <Input
+                    value={section.description ?? ""}
+                    onChange={(event) =>
+                      setSection(sectionIndex, {
+                        description: event.target.value,
+                      })
+                    }
+                    aria-label="Descricao da secao"
+                    placeholder="Descricao opcional"
+                  />
+                </div>
+                <div className="flex gap-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => moveSection(sectionIndex, -1)}
+                  >
+                    <ArrowUp className="h-4 w-4" />
+                    <span className="sr-only">Subir secao</span>
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => moveSection(sectionIndex, 1)}
+                  >
+                    <ArrowDown className="h-4 w-4" />
+                    <span className="sr-only">Descer secao</span>
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {section.fields.map((field, fieldIndex) => (
+                  <FieldEditor
+                    key={field.tempId}
+                    field={field}
+                    onChange={(patch) =>
+                      setField(sectionIndex, fieldIndex, patch)
+                    }
+                    onMoveUp={() => moveField(sectionIndex, fieldIndex, -1)}
+                    onMoveDown={() => moveField(sectionIndex, fieldIndex, 1)}
+                    onRemove={() =>
+                      setSection(sectionIndex, {
+                        fields: section.fields.filter((_, i) => i !== fieldIndex),
+                      })
+                    }
+                  />
+                ))}
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() =>
+                    setSection(sectionIndex, {
+                      fields: [
+                        ...section.fields,
+                        buildField(section.fields.length),
+                      ],
+                    })
+                  }
+                >
+                  <Plus className="h-4 w-4" />
+                  Adicionar campo
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() =>
+            setEditor({
+              ...editor,
+              sections: [
+                ...editor.sections,
+                {
+                  name: "Nova secao",
+                  description: "",
+                  order: editor.sections.length,
+                  isCollapsible: false,
+                  fields: [],
+                  tempId: tempId(),
+                },
+              ],
+            })
+          }
+        >
+          <Plus className="h-4 w-4" />
+          Adicionar secao
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function FieldEditor({
+  field,
+  onChange,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+}: {
+  field: EditorField;
+  onChange: (patch: Partial<EditorField>) => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+}) {
+  const meta = FIELD_TYPE_META[field.fieldType];
+  const Icon = meta.icon;
+
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="grid gap-3 lg:grid-cols-[1.2fr_1fr_180px_auto]">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Icon className="h-4 w-4 text-muted-foreground" />
+            <Input
+              value={field.label}
+              onChange={(event) => onChange({ label: event.target.value })}
+              aria-label="Label do campo"
+            />
+            {field.isSystemField && <Badge variant="secondary">Sistema</Badge>}
+          </div>
+          <Input
+            value={field.description ?? ""}
+            onChange={(event) => onChange({ description: event.target.value })}
+            placeholder="Texto de ajuda opcional"
+            aria-label="Descricao do campo"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Input
+            value={field.key}
+            onChange={(event) => onChange({ key: event.target.value })}
+            disabled={field.isSystemField}
+            aria-label="Chave do campo"
+          />
+          <ConfigEditor field={field} onChange={onChange} />
+        </div>
+
+        <div className="space-y-2">
+          <Select
+            value={field.fieldType}
+            onValueChange={(value: FormFieldType) =>
+              onChange({ fieldType: value })
+            }
+            disabled={field.isSystemField}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FIELD_TYPE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="flex flex-wrap gap-3 text-sm">
+            <label className="flex items-center gap-2">
+              <Switch
+                checked={field.isRequired}
+                onCheckedChange={(checked) => onChange({ isRequired: checked })}
+              />
+              Obrigatorio
+            </label>
+            <button
+              type="button"
+              className="flex items-center gap-1 text-muted-foreground hover:text-foreground"
+              onClick={() => onChange({ isVisible: !field.isVisible })}
+            >
+              {field.isVisible ? (
+                <Eye className="h-4 w-4" />
+              ) : (
+                <EyeOff className="h-4 w-4" />
+              )}
+              {field.isVisible ? "Visivel" : "Oculto"}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-1">
+          <Button type="button" variant="ghost" size="icon" onClick={onMoveUp}>
+            <ArrowUp className="h-4 w-4" />
+            <span className="sr-only">Subir campo</span>
+          </Button>
+          <Button type="button" variant="ghost" size="icon" onClick={onMoveDown}>
+            <ArrowDown className="h-4 w-4" />
+            <span className="sr-only">Descer campo</span>
+          </Button>
+          {!field.isSystemField && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={onRemove}
+            >
+              <Trash2 className="h-4 w-4" />
+              <span className="sr-only">Remover campo</span>
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConfigEditor({
+  field,
+  onChange,
+}: {
+  field: EditorField;
+  onChange: (patch: Partial<EditorField>) => void;
+}) {
+  const config = field.config ?? {};
+
+  if (field.fieldType === "NUMBER") {
+    return (
+      <Input
+        value={config.unit ?? ""}
+        placeholder="Unidade, ex: kg"
+        onChange={(event) =>
+          onChange({ config: { ...config, unit: event.target.value } })
+        }
+      />
+    );
+  }
+
+  if (field.fieldType === "SELECT" || field.fieldType === "RADIO") {
+    const optionsText = (config.options ?? [])
+      .map((option) => `${option.value}|${option.label}`)
+      .join("\n");
+
+    return (
+      <Textarea
+        value={optionsText}
+        rows={2}
+        placeholder={"valor|Label\noutro|Outro label"}
+        onChange={(event) =>
+          onChange({
+            config: {
+              ...config,
+              options: event.target.value
+                .split("\n")
+                .map((line) => line.trim())
+                .filter(Boolean)
+                .map((line) => {
+                  const [value, label] = line.split("|");
+                  return {
+                    value: value ?? "",
+                    label: label ?? value ?? "",
+                  };
+                }),
+            },
+          })
+        }
+      />
+    );
+  }
+
+  return (
+    <Input
+      value={config.placeholder ?? ""}
+      placeholder="Placeholder"
+      onChange={(event) =>
+        onChange({ config: { ...config, placeholder: event.target.value } })
+      }
+    />
+  );
+}

--- a/src/features/form-template-editor/components/template-list-page.tsx
+++ b/src/features/form-template-editor/components/template-list-page.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Copy, FileText, Pencil, Star, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { api } from "~/trpc/react";
+
+export function TemplateListPage() {
+  const router = useRouter();
+  const utils = api.useUtils();
+  const templates = api.formTemplate.list.useQuery();
+
+  const duplicate = api.formTemplate.duplicate.useMutation({
+    onSuccess: async (template) => {
+      await utils.formTemplate.list.invalidate();
+      toast.success("Template duplicado");
+      router.push(`/configuracoes/formularios/${template.id}`);
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const setDefault = api.formTemplate.setDefault.useMutation({
+    onSuccess: async () => {
+      await utils.formTemplate.list.invalidate();
+      toast.success("Template padrao atualizado");
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const archive = api.formTemplate.archive.useMutation({
+    onSuccess: async () => {
+      await utils.formTemplate.list.invalidate();
+      toast.success("Template arquivado");
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  return (
+    <div className="min-h-screen bg-background p-4 md:p-8">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold">Formularios de anamnese</h1>
+            <p className="text-muted-foreground">
+              Personalize as secoes e campos usados nas suas consultas.
+            </p>
+          </div>
+          {templates.data?.[0] && (
+            <Button
+              onClick={() => duplicate.mutate({ id: templates.data[0]!.id })}
+              disabled={duplicate.isPending}
+            >
+              <Copy className="h-4 w-4" />
+              Novo a partir do padrao
+            </Button>
+          )}
+        </div>
+
+        {templates.isLoading && (
+          <Card>
+            <CardContent className="py-10 text-center text-sm text-muted-foreground">
+              Carregando templates...
+            </CardContent>
+          </Card>
+        )}
+
+        <div className="grid gap-4">
+          {templates.data?.map((template) => (
+            <Card key={template.id}>
+              <CardHeader className="gap-3 sm:grid-cols-[1fr_auto]">
+                <div className="flex min-w-0 items-center gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                    <FileText className="h-5 w-5 text-primary" />
+                  </div>
+                  <div className="min-w-0">
+                    <CardTitle className="truncate">{template.name}</CardTitle>
+                    <p className="text-sm text-muted-foreground">
+                      {template.sections.length} secoes
+                    </p>
+                  </div>
+                  {template.isDefault && <Badge>Padrao</Badge>}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {!template.isDefault && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setDefault.mutate({ id: template.id })}
+                    >
+                      <Star className="h-4 w-4" />
+                      Padrao
+                    </Button>
+                  )}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => duplicate.mutate({ id: template.id })}
+                  >
+                    <Copy className="h-4 w-4" />
+                    Duplicar
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      router.push(`/configuracoes/formularios/${template.id}`)
+                    }
+                  >
+                    <Pencil className="h-4 w-4" />
+                    Editar
+                  </Button>
+                  {!template.isDefault && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => archive.mutate({ id: template.id })}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      Arquivar
+                    </Button>
+                  )}
+                </div>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/form-template-editor/constants/field-type-meta.ts
+++ b/src/features/form-template-editor/constants/field-type-meta.ts
@@ -1,0 +1,38 @@
+import {
+  Calendar,
+  CheckSquare,
+  CircleDot,
+  Hash,
+  HeartPulse,
+  ListChecks,
+  Pilcrow,
+  Pill,
+  TextCursorInput,
+} from "lucide-react";
+
+import type { FormFieldType } from "~/schemas/form-template";
+
+export const FIELD_TYPE_META: Record<
+  FormFieldType,
+  {
+    label: string;
+    icon: typeof Pilcrow;
+  }
+> = {
+  TEXT: { label: "Texto longo", icon: Pilcrow },
+  SHORT_TEXT: { label: "Texto curto", icon: TextCursorInput },
+  NUMBER: { label: "Numero", icon: Hash },
+  BOOLEAN: { label: "Sim/Nao", icon: CheckSquare },
+  SELECT: { label: "Lista", icon: ListChecks },
+  RADIO: { label: "Escolha unica", icon: CircleDot },
+  DATE: { label: "Data", icon: Calendar },
+  NYHA_CLASS: { label: "Classe NYHA", icon: HeartPulse },
+  MEDICATIONS: { label: "Medicamentos", icon: Pill },
+};
+
+export const FIELD_TYPE_OPTIONS = Object.entries(FIELD_TYPE_META).map(
+  ([value, meta]) => ({
+    value: value as FormFieldType,
+    label: meta.label,
+  }),
+);

--- a/src/features/form-template-editor/types/editor.types.ts
+++ b/src/features/form-template-editor/types/editor.types.ts
@@ -1,0 +1,34 @@
+import type { FormFieldConfig, FormFieldType } from "~/schemas/form-template";
+
+export type EditorField = {
+  id?: string;
+  key: string;
+  label: string;
+  description?: string | null;
+  order: number;
+  fieldType: FormFieldType;
+  isRequired: boolean;
+  isVisible: boolean;
+  isSystemField: boolean;
+  systemKey?: string | null;
+  config?: FormFieldConfig | null;
+  tempId: string;
+};
+
+export type EditorSection = {
+  id?: string;
+  name: string;
+  description?: string | null;
+  order: number;
+  isCollapsible: boolean;
+  fields: EditorField[];
+  tempId: string;
+};
+
+export type EditorState = {
+  id: string;
+  name: string;
+  description?: string | null;
+  isDefault: boolean;
+  sections: EditorSection[];
+};

--- a/src/features/layout/components/mobileSidebar.tsx
+++ b/src/features/layout/components/mobileSidebar.tsx
@@ -13,8 +13,8 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "~/components/ui/sheet";
-import { SIDEBAR_ITEMS } from "~/features/layout/constants/sidebarItems";
-import type { SidebarItemType } from "~/features/layout/types/sidebar.types";
+import { getVisibleSidebarItems } from "~/features/layout/constants/sidebarItems";
+import { api } from "~/trpc/react";
 import { SidebarItem } from "./sidebar";
 
 // Nova Logo
@@ -23,6 +23,8 @@ import logo from "../../../public/logo.jpg";
 export function MobileSidebar() {
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
+  const profile = api.profile.get.useQuery();
+  const sidebarItems = getVisibleSidebarItems(Boolean(profile.data?.superAdmin));
 
   useEffect(() => {
     setOpen(false);
@@ -59,12 +61,12 @@ export function MobileSidebar() {
                 </div>
             </div>
 
-            <ScrollArea className="flex-1 px-3 py-4">
+            <ScrollArea className="min-h-0 flex-1 px-3 py-4">
                 <nav className="flex flex-col gap-2">
-                {SIDEBAR_ITEMS.map((item) => (
+                {sidebarItems.map((item) => (
                     <SidebarItem
                         key={item.title}
-                        item={item as SidebarItemType}
+                        item={item}
                         isCollapsed={false}
                         pathname={pathname}
                     />

--- a/src/features/layout/components/sidebar.tsx
+++ b/src/features/layout/components/sidebar.tsx
@@ -26,16 +26,22 @@ import {
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { signOutAction } from "~/features/auth/actions/auth.actions";
+import { api } from "~/trpc/react";
 
-import type { SidebarItemProps, SidebarItemType } from "~/features/layout/types/sidebar.types";
+import type { SidebarItemProps } from "~/features/layout/types/sidebar.types";
 
 import logo from "../../../public/logo.jpg"; 
 
-import { SIDEBAR_ITEMS } from "~/features/layout/constants/sidebarItems";
+import { getVisibleSidebarItems } from "~/features/layout/constants/sidebarItems";
 
 export function Sidebar() {
   const [isCollapsed, setIsCollapsed] = React.useState(false);
   const pathname = usePathname();
+  const profile = api.profile.get.useQuery();
+  const sidebarItems = React.useMemo(
+    () => getVisibleSidebarItems(Boolean(profile.data?.superAdmin)),
+    [profile.data?.superAdmin],
+  );
 
   const handleLogout = async () => {
      await signOutAction();
@@ -45,7 +51,7 @@ export function Sidebar() {
     <TooltipProvider delayDuration={0}>
       <aside
         className={cn(
-          "relative flex flex-col h-screen bg-card border-r border-border transition-all duration-300 ease-in-out font-sans shadow-sm z-20",
+          "relative flex min-h-0 flex-col h-screen bg-card border-r border-border transition-all duration-300 ease-in-out font-sans shadow-sm z-20",
           isCollapsed ? "w-20" : "w-[260px]"
         )}
       >
@@ -100,12 +106,12 @@ export function Sidebar() {
             </div>
         )}
 
-        <ScrollArea className="flex-1 px-3 pt-2">
+        <ScrollArea className="min-h-0 flex-1 px-3 pt-2">
           <nav className="flex flex-col gap-2 pb-4">
-            {SIDEBAR_ITEMS.map((item) => (
+            {sidebarItems.map((item) => (
               <SidebarItem
                 key={item.title}
-                item={item as SidebarItemType}
+                item={item}
                 isCollapsed={isCollapsed}
                 pathname={pathname}
               />

--- a/src/features/layout/constants/sidebarItems.ts
+++ b/src/features/layout/constants/sidebarItems.ts
@@ -8,12 +8,14 @@ import {
   Stethoscope,
   Pill,
   Settings,
-  History,
   Activity,
-  FolderCode
+  FolderCode,
+  ClipboardList,
+  ShieldCheck
 } from "lucide-react";
+import type { SidebarItemType } from "~/features/layout/types/sidebar.types";
 
-export const SIDEBAR_ITEMS = [
+export const SIDEBAR_ITEMS: SidebarItemType[] = [
   {
     title: "Visão Geral",
     icon: LayoutDashboard,
@@ -67,8 +69,17 @@ export const SIDEBAR_ITEMS = [
   {
     title: "Configurações",
     icon: Settings,
-    href: "/profile",
-    type: "link"
+    type: "group",
+    subItems: [
+      { title: "Minha Conta", href: "/profile", icon: Settings },
+      { title: "Formulários", href: "/configuracoes/formularios", icon: ClipboardList },
+      {
+        title: "Super Admin",
+        href: "/configuracoes/superadmin",
+        icon: ShieldCheck,
+        superAdminOnly: true,
+      },
+    ]
   },
   {
     title: "StyleGuide",
@@ -77,3 +88,18 @@ export const SIDEBAR_ITEMS = [
     type: "link"
   }
 ];
+
+export const getVisibleSidebarItems = (isSuperAdmin: boolean) =>
+  SIDEBAR_ITEMS
+    .filter((item) => !item.superAdminOnly || isSuperAdmin)
+    .map((item) => {
+      if (!item.subItems) return item;
+
+      return {
+        ...item,
+        subItems: item.subItems.filter(
+          (subItem) => !subItem.superAdminOnly || isSuperAdmin,
+        ),
+      };
+    })
+    .filter((item) => item.type === "link" || (item.subItems?.length ?? 0) > 0);

--- a/src/features/layout/types/sidebar.types.ts
+++ b/src/features/layout/types/sidebar.types.ts
@@ -10,6 +10,7 @@ export type SubItemType = {
   title: string;
   href: string;
   icon?: LucideIcon;
+  superAdminOnly?: boolean;
 };
 
 export type SidebarItemType = {
@@ -18,4 +19,5 @@ export type SidebarItemType = {
   href?: string;
   type: "link" | "group";
   subItems?: SubItemType[];
+  superAdminOnly?: boolean;
 };

--- a/src/features/patients/components/anamnesis-detail-dialog.tsx
+++ b/src/features/patients/components/anamnesis-detail-dialog.tsx
@@ -10,10 +10,25 @@ import { Dialog, DialogContent, DialogTitle } from "~/components/ui/dialog";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { api } from "~/trpc/react";
+import { DynamicFieldRenderer } from "~/features/anamnesis/components/dynamic-field-renderer";
+import type { FormFieldType } from "~/schemas/form-template";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 type Medication = { name: string; dosage: string; frequency: string };
+type CustomResponses = Record<string, unknown>;
+
+type TemplateField = {
+  id: string;
+  key: string;
+  label: string;
+  description?: string | null;
+  fieldType: FormFieldType;
+  isRequired: boolean;
+  isVisible: boolean;
+  config?: unknown;
+  isSystemField: boolean;
+};
 
 type PhysicalExam = {
   weight?: number | null;
@@ -46,6 +61,12 @@ export type AnamnesisDetail = {
   nextRecallDate?: Date | null;
   physicalExam?: PhysicalExam | null;
   medications: Medication[];
+  customResponses?: unknown;
+  template?: {
+    sections: Array<{
+      fields: TemplateField[];
+    }>;
+  } | null;
 };
 
 type FormState = {
@@ -75,6 +96,7 @@ type FormState = {
     edemaGrade: string;
   };
   medications: Medication[];
+  customResponses: CustomResponses;
 };
 
 type Props = {
@@ -85,6 +107,11 @@ type Props = {
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const toRecord = (value: unknown): CustomResponses =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as CustomResponses)
+    : {};
 
 const toForm = (a: AnamnesisDetail): FormState => ({
   chiefComplaint: a.chiefComplaint,
@@ -115,6 +142,7 @@ const toForm = (a: AnamnesisDetail): FormState => ({
     edemaGrade: a.physicalExam?.edemaGrade ?? "",
   },
   medications: a.medications.map((m) => ({ ...m })),
+  customResponses: toRecord(a.customResponses),
 });
 
 const num = (v: string) => (v === "" ? undefined : Number(v));
@@ -141,7 +169,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 function ReadText({ value, empty = "—" }: { value?: string | null; empty?: string }) {
   return (
     <p className="text-sm text-foreground whitespace-pre-line leading-relaxed">
-      {value || empty}
+      {value ?? empty}
     </p>
   );
 }
@@ -218,6 +246,12 @@ export function AnamnesisDetailDialog({ anamnesis, open, onClose, patientId }: P
       return { ...prev, medications: meds };
     });
 
+  const setCustom = (key: string, value: unknown) =>
+    setForm((prev) => ({
+      ...prev,
+      customResponses: { ...prev.customResponses, [key]: value },
+    }));
+
   const cancel = () => {
     setForm(toForm(anamnesis));
     setEditing(false);
@@ -252,6 +286,7 @@ export function AnamnesisDetailDialog({ anamnesis, open, onClose, patientId }: P
         edemaGrade: form.physicalExam.edemaGrade || null,
       },
       medications: form.medications.filter((m) => m.name.trim()),
+      customResponses: form.customResponses,
     });
   };
 
@@ -262,6 +297,10 @@ export function AnamnesisDetailDialog({ anamnesis, open, onClose, patientId }: P
     form.hasEdema && "Edema",
     form.hasChestPain && "Dor torácica",
   ].filter(Boolean) as string[];
+  const customFields =
+    anamnesis.template?.sections.flatMap((section) =>
+      section.fields.filter((field) => !field.isSystemField && field.isVisible),
+    ) ?? [];
 
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
@@ -459,6 +498,21 @@ export function AnamnesisDetailDialog({ anamnesis, open, onClose, patientId }: P
                   )}
                 </Field>
               </div>
+
+              {customFields.length > 0 && (
+                <div className="rounded-xl border border-border bg-card p-5 space-y-4">
+                  <SectionTitle>Campos Personalizados</SectionTitle>
+                  {customFields.map((field) => (
+                    <DynamicFieldRenderer
+                      key={field.id}
+                      field={field}
+                      value={form.customResponses[field.key]}
+                      onChange={(value) => setCustom(field.key, value)}
+                      readOnly={!editing}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
 
             {/* ── Right column (1/3) ── */}

--- a/src/features/patients/components/anamnesis-detail-page.tsx
+++ b/src/features/patients/components/anamnesis-detail-page.tsx
@@ -10,6 +10,7 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { api } from "~/trpc/react";
 import type { AnamnesisDetail } from "./anamnesis-detail-dialog";
+import { DynamicFieldRenderer } from "~/features/anamnesis/components/dynamic-field-renderer";
 
 type FormState = {
   chiefComplaint: string;
@@ -31,6 +32,7 @@ type FormState = {
     lungAuscultation: string; peripheralPulses: string; edemaGrade: string;
   };
   medications: { name: string; dosage: string; frequency: string }[];
+  customResponses: Record<string, unknown>;
 };
 
 type Props = {
@@ -40,6 +42,11 @@ type Props = {
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const toRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
 
 const toForm = (a: AnamnesisDetail): FormState => ({
   chiefComplaint: a.chiefComplaint,
@@ -70,6 +77,7 @@ const toForm = (a: AnamnesisDetail): FormState => ({
     edemaGrade: a.physicalExam?.edemaGrade ?? "",
   },
   medications: a.medications.map((m) => ({ ...m })),
+  customResponses: toRecord(a.customResponses),
 });
 
 const num = (v: string) => (v === "" ? undefined : Number(v));
@@ -103,7 +111,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 function ReadText({ value, empty = "—" }: { value?: string | null; empty?: string }) {
   return (
     <p className="text-sm text-foreground whitespace-pre-line leading-relaxed">
-      {value || empty}
+      {value ?? empty}
     </p>
   );
 }
@@ -166,6 +174,12 @@ export function AnamnesisDetailPage({ anamnesis, patientId, onBack }: Props) {
       ),
     }));
 
+  const setCustom = (key: string, value: unknown) =>
+    setForm((prev) => ({
+      ...prev,
+      customResponses: { ...prev.customResponses, [key]: value },
+    }));
+
   const cancel = () => { setForm(toForm(anamnesis)); setEditing(false); };
 
   const save = () => {
@@ -197,6 +211,7 @@ export function AnamnesisDetailPage({ anamnesis, patientId, onBack }: Props) {
         edemaGrade: form.physicalExam.edemaGrade || null,
       },
       medications: form.medications.filter((m) => m.name.trim()),
+      customResponses: form.customResponses,
     });
   };
 
@@ -207,6 +222,10 @@ export function AnamnesisDetailPage({ anamnesis, patientId, onBack }: Props) {
     form.hasEdema && "Edema",
     form.hasChestPain && "Dor torácica",
   ].filter(Boolean) as string[];
+  const customFields =
+    anamnesis.template?.sections.flatMap((section) =>
+      section.fields.filter((field) => !field.isSystemField && field.isVisible),
+    ) ?? [];
 
   return (
     <div className="flex flex-col h-full">
@@ -400,6 +419,21 @@ export function AnamnesisDetailPage({ anamnesis, patientId, onBack }: Props) {
                 )}
               </Field>
             </div>
+
+            {customFields.length > 0 && (
+              <div className="rounded-xl border border-border bg-card p-5 space-y-4">
+                <SectionTitle>Campos Personalizados</SectionTitle>
+                {customFields.map((field) => (
+                  <DynamicFieldRenderer
+                    key={field.id}
+                    field={field}
+                    value={form.customResponses[field.key]}
+                    onChange={(value) => setCustom(field.key, value)}
+                    readOnly={!editing}
+                  />
+                ))}
+              </div>
+            )}
           </div>
 
           {/* ── Right (1/3) ── */}

--- a/src/schemas/anamnesis.ts
+++ b/src/schemas/anamnesis.ts
@@ -6,6 +6,8 @@ export const createAnamnesisSchema = z.object({
   patientId: z.string().cuid(),
 
   consultationId: z.string().cuid().optional(),
+  templateId: z.string().cuid().optional(),
+  customResponses: z.record(z.string(), z.unknown()).optional(),
   chiefComplaint: z.string().min(1, "Campo obrigatório"),
   currentIllnessHistory: z.string().min(1, "Campo obrigatório"),
   treatmentResponse: z.string().optional(),
@@ -52,6 +54,8 @@ export type CreateAnamnesisInput = z.infer<typeof createAnamnesisSchema>;
 
 export const updateAnamnesisSchema = z.object({
   id: z.string().cuid(),
+  templateId: z.string().cuid().nullable().optional(),
+  customResponses: z.record(z.string(), z.unknown()).optional(),
   chiefComplaint: z.string().min(1).optional(),
   currentIllnessHistory: z.string().min(1).optional(),
   treatmentResponse: z.string().nullable().optional(),

--- a/src/schemas/audio-anamnesis-form.ts
+++ b/src/schemas/audio-anamnesis-form.ts
@@ -73,9 +73,20 @@ const anamnesisFormSchema = z.object({
 export const consolidatedFormStateSchema = z.object({
   patient: patientFormSchema.default({}),
   anamnesis: anamnesisFormSchema.default({}),
+  customFields: z.record(z.string(), z.unknown()).default({}),
+  templateId: z.string().nullable().optional(),
 });
 
 export type ConsolidatedFormState = z.infer<typeof consolidatedFormStateSchema>;
+
+type EmptyConsolidatedFormStatePartial = {
+  patient?: Omit<Partial<ConsolidatedFormState["patient"]>, "clinicalProfile"> & {
+    clinicalProfile?: Partial<ConsolidatedFormState["patient"]["clinicalProfile"]>;
+  };
+  anamnesis?: Partial<ConsolidatedFormState["anamnesis"]>;
+  customFields?: Record<string, unknown>;
+  templateId?: string | null;
+};
 
 export const fieldOperationSchema = z.object({
   action: z.enum(["replace", "append", "merge", "noop"]),
@@ -90,10 +101,7 @@ export const llmExtractionResponseSchema = z.object({
 export type LlmExtractionResponse = z.infer<typeof llmExtractionResponseSchema>;
 
 export const buildEmptyConsolidatedFormState = (
-  partial?: Partial<{
-    patient: Partial<ConsolidatedFormState["patient"]>;
-    anamnesis: Partial<ConsolidatedFormState["anamnesis"]>;
-  }>,
+  partial?: EmptyConsolidatedFormStatePartial,
 ): ConsolidatedFormState => {
   return consolidatedFormStateSchema.parse({
     patient: {
@@ -121,10 +129,41 @@ export const buildEmptyConsolidatedFormState = (
       conduct: partial?.anamnesis?.conduct ?? "",
       nextRecallDate: partial?.anamnesis?.nextRecallDate ?? null,
     },
+    customFields: partial?.customFields ?? {},
+    templateId: partial?.templateId ?? null,
   });
 };
 
-export const consolidatedFormStateSchemaDescription = `Schema esperado (JSON):
+type TemplateForSchemaDescription = {
+  sections: Array<{
+    name: string;
+    fields: Array<{
+      key: string;
+      label: string;
+      fieldType: string;
+      description?: string | null;
+      isSystemField: boolean;
+    }>;
+  }>;
+};
+
+const describeCustomFields = (template?: TemplateForSchemaDescription | null) => {
+  const fields =
+    template?.sections.flatMap((section) =>
+      section.fields
+        .filter((field) => !field.isSystemField)
+        .map((field) => {
+          const description = field.description ? ` - ${field.description}` : "";
+          return `    "${field.key}": ${field.fieldType} // ${field.label}${description}`;
+        }),
+    ) ?? [];
+
+  return fields.length ? fields.join(",\n") : "    // nenhum campo personalizado";
+};
+
+export const buildConsolidatedFormStateSchemaDescription = (
+  template?: TemplateForSchemaDescription | null,
+) => `Schema esperado (JSON):
 {
   "patient": {
     "name": string,
@@ -176,5 +215,12 @@ export const consolidatedFormStateSchemaDescription = `Schema esperado (JSON):
     "diagnosticHypothesis": string,
     "conduct": string,
     "nextRecallDate": string ISO ou null
-  }
+  },
+  "customFields": {
+${describeCustomFields(template)}
+  },
+  "templateId": string | null
 }`;
+
+export const consolidatedFormStateSchemaDescription =
+  buildConsolidatedFormStateSchemaDescription();

--- a/src/schemas/form-template.ts
+++ b/src/schemas/form-template.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+
+export const formFieldTypeSchema = z.enum([
+  "TEXT",
+  "SHORT_TEXT",
+  "NUMBER",
+  "BOOLEAN",
+  "SELECT",
+  "RADIO",
+  "DATE",
+  "NYHA_CLASS",
+  "MEDICATIONS",
+]);
+
+export type FormFieldType = z.infer<typeof formFieldTypeSchema>;
+
+export const formFieldOptionSchema = z.object({
+  value: z.string().min(1),
+  label: z.string().min(1),
+});
+
+export const formFieldConfigSchema = z
+  .object({
+    options: z.array(formFieldOptionSchema).optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+    step: z.number().optional(),
+    unit: z.string().optional(),
+    placeholder: z.string().optional(),
+    maxLength: z.number().int().positive().optional(),
+    trueLabel: z.string().optional(),
+    falseLabel: z.string().optional(),
+  })
+  .passthrough();
+
+export type FormFieldConfig = z.infer<typeof formFieldConfigSchema>;
+
+export const upsertFormFieldSchema = z.object({
+  id: z.string().cuid().optional(),
+  key: z
+    .string()
+    .min(1)
+    .regex(/^[A-Za-z][A-Za-z0-9_]*$/, "Use apenas letras, numeros e underline"),
+  label: z.string().min(1),
+  description: z.string().optional().nullable(),
+  order: z.number().int().min(0),
+  fieldType: formFieldTypeSchema,
+  isRequired: z.boolean().default(false),
+  isVisible: z.boolean().default(true),
+  config: formFieldConfigSchema.optional().nullable(),
+  isSystemField: z.boolean().optional(),
+  systemKey: z.string().optional().nullable(),
+});
+
+export const upsertFormSectionSchema = z.object({
+  id: z.string().cuid().optional(),
+  name: z.string().min(1),
+  description: z.string().optional().nullable(),
+  order: z.number().int().min(0),
+  isCollapsible: z.boolean().default(false),
+  fields: z.array(upsertFormFieldSchema),
+});
+
+export const createFormTemplateSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional().nullable(),
+  isDefault: z.boolean().default(false),
+  sections: z.array(upsertFormSectionSchema).min(1),
+});
+
+export const updateFormTemplateSchema = createFormTemplateSchema
+  .partial()
+  .extend({
+    id: z.string().cuid(),
+  });
+
+export type CreateFormTemplateInput = z.infer<typeof createFormTemplateSchema>;
+export type UpdateFormTemplateInput = z.infer<typeof updateFormTemplateSchema>;
+
+export const SYSTEM_ANAMNESIS_FIELD_KEYS = [
+  "chiefComplaint",
+  "currentIllnessHistory",
+  "treatmentResponse",
+  "symptomEvolution",
+  "newEvents",
+  "nyhaClass",
+  "hasPalpitations",
+  "hasSyncope",
+  "hasEdema",
+  "hasChestPain",
+  "weight",
+  "height",
+  "bpSystolic",
+  "bpDiastolic",
+  "heartRate",
+  "oxygenSaturation",
+  "heartAuscultation",
+  "lungAuscultation",
+  "peripheralPulses",
+  "edemaGrade",
+  "medications",
+  "diagnosticHypothesis",
+  "conduct",
+  "nextRecallDate",
+] as const;
+
+export const SYSTEM_ANAMNESIS_FIELD_KEY_SET = new Set<string>(
+  SYSTEM_ANAMNESIS_FIELD_KEYS,
+);

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -7,6 +7,7 @@ import { scheduleConsultationRouter } from "~/server/api/routers/scheduleConsult
 import { aiDiagnosisRouter } from "~/server/api/routers/aiDiagnosis.router";
 import { creditsRouter } from "~/server/api/routers/credits.router";
 import { audioConsultationRouter } from "~/server/api/routers/audioConsultation.router";
+import { formTemplateRouter } from "~/server/api/routers/formTemplate.router";
 
 export const appRouter = createTRPCRouter({
   profile: profileRouter,
@@ -16,6 +17,7 @@ export const appRouter = createTRPCRouter({
   aiDiagnosis: aiDiagnosisRouter,
   credits: creditsRouter,
   audioConsultation: audioConsultationRouter,
+  formTemplate: formTemplateRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/api/routers/formTemplate.router.ts
+++ b/src/server/api/routers/formTemplate.router.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+import {
+  createFormTemplateSchema,
+  updateFormTemplateSchema,
+} from "~/schemas/form-template";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import * as formTemplateService from "~/server/services/formTemplate.service";
+
+export const formTemplateRouter = createTRPCRouter({
+  getDefault: protectedProcedure.query(({ ctx }) =>
+    formTemplateService.getDefaultTemplate(ctx.db, ctx.user.id),
+  ),
+
+  list: protectedProcedure.query(({ ctx }) =>
+    formTemplateService.listTemplates(ctx.db, ctx.user.id),
+  ),
+
+  getById: protectedProcedure
+    .input(z.object({ id: z.string().cuid() }))
+    .query(({ ctx, input }) =>
+      formTemplateService.getTemplateById(ctx.db, ctx.user.id, input.id),
+    ),
+
+  create: protectedProcedure
+    .input(createFormTemplateSchema)
+    .mutation(({ ctx, input }) =>
+      formTemplateService.createTemplate(ctx.db, ctx.user.id, input),
+    ),
+
+  update: protectedProcedure
+    .input(updateFormTemplateSchema)
+    .mutation(({ ctx, input }) =>
+      formTemplateService.updateTemplate(ctx.db, ctx.user.id, input),
+    ),
+
+  setDefault: protectedProcedure
+    .input(z.object({ id: z.string().cuid() }))
+    .mutation(({ ctx, input }) =>
+      formTemplateService.setDefaultTemplate(ctx.db, ctx.user.id, input.id),
+    ),
+
+  duplicate: protectedProcedure
+    .input(z.object({ id: z.string().cuid() }))
+    .mutation(({ ctx, input }) =>
+      formTemplateService.duplicateTemplate(ctx.db, ctx.user.id, input.id),
+    ),
+
+  archive: protectedProcedure
+    .input(z.object({ id: z.string().cuid() }))
+    .mutation(({ ctx, input }) =>
+      formTemplateService.archiveTemplate(ctx.db, ctx.user.id, input.id),
+    ),
+});

--- a/src/server/services/anamnesis.service.ts
+++ b/src/server/services/anamnesis.service.ts
@@ -1,6 +1,11 @@
 // src/server/services/anamnesis.service.ts
 import { type PrismaClient } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
+import {
+  getDefaultTemplate,
+  getTemplateById,
+  sanitizeCustomResponses,
+} from "~/server/services/formTemplate.service";
 
 export const getByPatient = async (
   db: PrismaClient,
@@ -11,7 +16,18 @@ export const getByPatient = async (
     return await db.anamnesis.findMany({
       where: { patientId, profileId },
       orderBy: { date: "desc" },
-      include: { physicalExam: true, medications: true },
+      include: {
+        physicalExam: true,
+        medications: true,
+        template: {
+          include: {
+            sections: {
+              orderBy: { order: "asc" },
+              include: { fields: { orderBy: { order: "asc" } } },
+            },
+          },
+        },
+      },
     });
   } catch (error) {
     console.error("[Anamnesis - getByPatient]: ", error);
@@ -26,18 +42,23 @@ export const createAnamnesis = async (
   profileId: string,
   data: CreateAnamnesisInput,
 ) => {
-  const { physicalExam, medications, ...anamnesisData } = data;
+  const { physicalExam, medications, templateId, customResponses, ...anamnesisData } = data;
+  const template = templateId
+    ? await getTemplateById(db, profileId, templateId)
+    : await getDefaultTemplate(db, profileId);
 
   const anamnesis = await db.anamnesis.create({
     data: {
       ...anamnesisData,
       profileId,
+      templateId: template.id,
+      customResponses: sanitizeCustomResponses(customResponses),
       physicalExam: physicalExam ? { create: physicalExam } : undefined,
       medications: medications
         ? { createMany: { data: medications } }
         : undefined,
     },
-    include: { physicalExam: true, medications: true },
+    include: { physicalExam: true, medications: true, template: true },
   });
 
   void triggerDiagnosis(data.patientId, anamnesis.id);
@@ -48,15 +69,23 @@ export const createAnamnesis = async (
 export const updateAnamnesis = async (
   db: PrismaClient,
   profileId: string,
-  { id, physicalExam, medications, ...fields }: UpdateAnamnesisInput,
+  { id, physicalExam, medications, customResponses, templateId, ...fields }: UpdateAnamnesisInput,
 ) => {
   const existing = await db.anamnesis.findFirst({ where: { id, profileId } });
   if (!existing) throw new TRPCError({ code: "NOT_FOUND", message: "Anamnese não encontrada" });
+
+  if (templateId) {
+    await getTemplateById(db, profileId, templateId);
+  }
 
   return db.anamnesis.update({
     where: { id },
     data: {
       ...fields,
+      templateId,
+      customResponses: customResponses
+        ? sanitizeCustomResponses(customResponses)
+        : undefined,
       physicalExam: physicalExam
         ? { upsert: { create: physicalExam, update: physicalExam } }
         : undefined,
@@ -64,7 +93,7 @@ export const updateAnamnesis = async (
         ? { deleteMany: {}, createMany: { data: medications } }
         : undefined,
     },
-    include: { physicalExam: true, medications: true },
+    include: { physicalExam: true, medications: true, template: true },
   });
 };
 

--- a/src/server/services/audio/services/session.service.ts
+++ b/src/server/services/audio/services/session.service.ts
@@ -1,4 +1,4 @@
-import { type PrismaClient, Prisma } from "@prisma/client";
+import type { AudioBatchStatus, Prisma, PrismaClient } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import {
   buildEmptyConsolidatedFormState,
@@ -8,10 +8,22 @@ import {
 import type { CreateAnamnesisInput } from "~/schemas/anamnesis";
 import { assertMinimumBalanceForSession } from "~/server/services/credits/creditLedger.service";
 import { createAnamnesis } from "~/server/services/anamnesis.service";
+import { getDefaultTemplate } from "~/server/services/formTemplate.service";
 
 // ── Mapper ─────────────────────────────────────────────────────────────────────
 
 type MapContext = { patientId: string; consultationId?: string };
+
+const OPEN_BATCH_STATUSES: AudioBatchStatus[] = ["PENDING", "PROCESSING"];
+
+const getMetadataNumber = (metadata: Prisma.JsonValue | null, key: string) => {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return 0;
+  }
+
+  const value = (metadata as Record<string, unknown>)[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+};
 
 /**
  * Converts a consolidated audio-consultation form state into the input shape
@@ -26,7 +38,7 @@ const mapConsolidatedFormToAnamnesisInput = (
   const px = a.physicalExam;
 
   const physicalExam =
-    px.weight ??
+    (px.weight ??
     px.height ??
     px.bpSystolic ??
     px.bpDiastolic ??
@@ -35,7 +47,7 @@ const mapConsolidatedFormToAnamnesisInput = (
     px.heartAuscultation ??
     px.lungAuscultation ??
     px.peripheralPulses ??
-    px.edemaGrade
+    px.edemaGrade)
       ? {
           weight: px.weight ?? undefined,
           height: px.height ?? undefined,
@@ -54,7 +66,8 @@ const mapConsolidatedFormToAnamnesisInput = (
     patientId: ctx.patientId,
     consultationId: ctx.consultationId,
     chiefComplaint: a.chiefComplaint || "Coletado por captura de audio",
-    currentIllnessHistory: a.currentIllnessHistory || "Coletado por captura de audio",
+    currentIllnessHistory:
+      a.currentIllnessHistory || "Coletado por captura de audio",
     treatmentResponse: a.treatmentResponse || undefined,
     symptomEvolution: a.symptomEvolution || undefined,
     newEvents: a.newEvents || undefined,
@@ -68,6 +81,8 @@ const mapConsolidatedFormToAnamnesisInput = (
     diagnosticHypothesis: a.diagnosticHypothesis || undefined,
     conduct: a.conduct || undefined,
     nextRecallDate: a.nextRecallDate ?? undefined,
+    templateId: form.templateId ?? undefined,
+    customResponses: form.customFields,
   };
 };
 
@@ -98,12 +113,19 @@ export const startSession = async (
   });
 
   if (!patient) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Paciente nao encontrado" });
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Paciente nao encontrado",
+    });
   }
 
   if (input.consultationId) {
     const consultation = await db.scheduleConsultation.findFirst({
-      where: { id: input.consultationId, profileId, patientId: input.patientId },
+      where: {
+        id: input.consultationId,
+        profileId,
+        patientId: input.patientId,
+      },
       select: { id: true },
     });
     if (!consultation) {
@@ -115,12 +137,20 @@ export const startSession = async (
   }
 
   await assertMinimumBalanceForSession(db, profileId);
+  const template = await getDefaultTemplate(db, profileId);
+  const customFields = Object.fromEntries(
+    template.sections
+      .flatMap((section) => section.fields)
+      .filter((field) => !field.isSystemField)
+      .map((field) => [field.key, null]),
+  );
 
   const initialFormState = buildEmptyConsolidatedFormState({
     patient: {
       name: patient.name,
       birthDate: patient.birthDate,
-      gender: (patient.gender as ConsolidatedFormState["patient"]["gender"]) ?? null,
+      gender:
+        (patient.gender as ConsolidatedFormState["patient"]["gender"]) ?? null,
       cpf: patient.cpf ?? "",
       clinicalProfile: patient.clinicalProfile
         ? {
@@ -131,12 +161,16 @@ export const startSession = async (
             hasDyslipidemia: patient.clinicalProfile.hasDyslipidemia,
             hasPriorInfarction: patient.clinicalProfile.hasPriorInfarction,
             priorSurgeries: patient.clinicalProfile.priorSurgeries ?? "",
-            familyHistoryCoronaryEarly: patient.clinicalProfile.familyHistoryCoronaryEarly,
-            familyHistorySuddenDeath: patient.clinicalProfile.familyHistorySuddenDeath,
-            familyHistoryOthers: patient.clinicalProfile.familyHistoryOthers ?? "",
+            familyHistoryCoronaryEarly:
+              patient.clinicalProfile.familyHistoryCoronaryEarly,
+            familyHistorySuddenDeath:
+              patient.clinicalProfile.familyHistorySuddenDeath,
+            familyHistoryOthers:
+              patient.clinicalProfile.familyHistoryOthers ?? "",
             smokingStatus: patient.clinicalProfile.smokingStatus,
             smokingPacksYear: patient.clinicalProfile.smokingPacksYear,
-            alcoholConsumption: patient.clinicalProfile.alcoholConsumption ?? "",
+            alcoholConsumption:
+              patient.clinicalProfile.alcoholConsumption ?? "",
             exerciseLevel: patient.clinicalProfile.exerciseLevel,
           }
         : {},
@@ -144,6 +178,8 @@ export const startSession = async (
     anamnesis: {
       consultationId: input.consultationId ?? null,
     },
+    customFields,
+    templateId: template.id,
   });
 
   const session = await db.audioConsultationSession.create({
@@ -178,10 +214,86 @@ export const getSession = async (
   });
 
   if (!session) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Sessao nao encontrada" });
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Sessao nao encontrada",
+    });
   }
 
   return session;
+};
+
+export const getReviewSummary = async (
+  db: PrismaClient,
+  profileId: string,
+  sessionId: string,
+) => {
+  const session = await db.audioConsultationSession.findFirst({
+    where: { id: sessionId, profileId },
+    select: {
+      id: true,
+      status: true,
+      startedAt: true,
+      endedAt: true,
+      creditsConsumed: true,
+    },
+  });
+
+  if (!session) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Sessao nao encontrada",
+    });
+  }
+
+  const [pendingBatchCount, batches, ledgerEntries] = await Promise.all([
+    db.audioBatchRecord.count({
+      where: { sessionId, status: { in: OPEN_BATCH_STATUSES } },
+    }),
+    db.audioBatchRecord.findMany({
+      where: { sessionId },
+      select: { audioDurationSeconds: true },
+    }),
+    db.creditLedgerEntry.findMany({
+      where: { profileId, sessionId },
+      select: { metadata: true },
+    }),
+  ]);
+
+  const inputTokens = ledgerEntries.reduce(
+    (total, entry) => total + getMetadataNumber(entry.metadata, "inputTokens"),
+    0,
+  );
+  const outputTokens = ledgerEntries.reduce(
+    (total, entry) => total + getMetadataNumber(entry.metadata, "outputTokens"),
+    0,
+  );
+  const transcriptionSeconds = batches.reduce(
+    (total, batch) => total + batch.audioDurationSeconds,
+    0,
+  );
+  const durationSeconds = Math.max(
+    0,
+    Math.round(
+      ((session.endedAt ?? new Date()).getTime() -
+        session.startedAt.getTime()) /
+        1000,
+    ),
+  );
+
+  return {
+    sessionId: session.id,
+    status: session.status,
+    pendingBatchCount,
+    startedAt: session.startedAt,
+    endedAt: session.endedAt,
+    durationSeconds,
+    transcriptionSeconds,
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    creditsConsumed: session.creditsConsumed,
+  };
 };
 
 /**
@@ -218,20 +330,40 @@ export const finalizeSession = async (
   db: PrismaClient,
   profileId: string,
   sessionId: string,
+  formStateOverride?: ConsolidatedFormState,
 ) => {
   const session = await db.audioConsultationSession.findFirst({
     where: { id: sessionId, profileId },
   });
 
   if (!session) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Sessao nao encontrada" });
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Sessao nao encontrada",
+    });
   }
 
   if (session.status === "FINALIZED") {
-    throw new TRPCError({ code: "BAD_REQUEST", message: "Sessao ja foi finalizada" });
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Sessao ja foi finalizada",
+    });
   }
 
-  const parsed = consolidatedFormStateSchema.parse(session.currentFormState);
+  const pendingBatchCount = await db.audioBatchRecord.count({
+    where: { sessionId, status: { in: OPEN_BATCH_STATUSES } },
+  });
+
+  if (pendingBatchCount > 0 || session.status === "PROCESSING") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Aguarde o processamento dos lotes de audio antes de finalizar",
+    });
+  }
+
+  const parsed = consolidatedFormStateSchema.parse(
+    formStateOverride ?? session.currentFormState,
+  );
 
   const anamnesisInput = mapConsolidatedFormToAnamnesisInput(parsed, {
     patientId: session.patientId,
@@ -242,7 +374,11 @@ export const finalizeSession = async (
 
   await db.audioConsultationSession.update({
     where: { id: sessionId },
-    data: { status: "FINALIZED", endedAt: new Date() },
+    data: {
+      status: "FINALIZED",
+      endedAt: new Date(),
+      currentFormState: parsed as unknown as Prisma.InputJsonValue,
+    },
   });
 
   return { sessionId, anamnesisId: anamnesis.id };

--- a/src/server/services/audio/services/worker.service.ts
+++ b/src/server/services/audio/services/worker.service.ts
@@ -1,10 +1,10 @@
-import { type PrismaClient, Prisma } from "@prisma/client";
+import type { Prisma, PrismaClient } from "@prisma/client";
 import { calculateCreditConsumptionBreakdown } from "~/server/ai/credits/utils";
 import { getAudioTranscriber } from "~/server/ai/transcription";
 import { aiClientAudio } from "~/server/ai";
 import {
   consolidatedFormStateSchema,
-  consolidatedFormStateSchemaDescription,
+  buildConsolidatedFormStateSchemaDescription,
   llmExtractionResponseSchema,
   type ConsolidatedFormState,
 } from "~/schemas/audio-anamnesis-form";
@@ -15,6 +15,7 @@ import {
 } from "~/server/services/credits/creditLedger.service";
 import { deleteAudioBatch, downloadAudioFromSignedUrl } from "./batchStorage.service";
 import type { MergeContext, MergeResult } from "../entities/audio.entity";
+import { getDefaultTemplate, getTemplateById } from "~/server/services/formTemplate.service";
 
 // ── LLM merge ─────────────────────────────────────────────────────────────────
 
@@ -36,7 +37,22 @@ const buildUserPrompt = (
   ctx: MergeContext,
   currentFormState: ConsolidatedFormState,
   transcript: string,
-) => `Contexto da sessao:
+  template?: Awaited<ReturnType<typeof getDefaultTemplate>>,
+) => {
+  const customFieldLines =
+    template?.sections.flatMap((section) =>
+      section.fields
+        .filter((field) => !field.isSystemField)
+        .map(
+          (field) =>
+            `- customFields.${field.key} (${field.fieldType}): "${field.label}"`,
+        ),
+    ) ?? [];
+  const customFieldsDescription = customFieldLines.length
+    ? customFieldLines.join("\n")
+    : "Nenhum";
+
+  return `Contexto da sessao:
 - sessionId: ${ctx.sessionId}
 - patientId: ${ctx.patientId}
 - consultationId: ${ctx.consultationId ?? "null"}
@@ -45,7 +61,10 @@ const buildUserPrompt = (
 Observacao importante:
 O inicio desta transcricao pode repetir os ultimos segundos do lote anterior. Considere essas frases como overlap e nao como informacao nova por padrao.
 
-${consolidatedFormStateSchemaDescription}
+${buildConsolidatedFormStateSchemaDescription(template)}
+
+Campos personalizados do medico a preencher em customFields:
+${customFieldsDescription}
 
 Formulario atual (JSON):
 ${JSON.stringify(currentFormState)}
@@ -56,6 +75,7 @@ Nova transcricao:
 Retorne um objeto JSON com exatamente as chaves:
 1. "nextFormState" - o JSON consolidado atualizado, mantendo o mesmo schema do formulario atual.
 2. "fieldOperations" - mapa de "secao.campo" => { "action": "replace"|"append"|"merge"|"noop", "reason": string }.`;
+};
 
 /**
  * Calls the LLM to merge a new audio transcript into the current form state.
@@ -71,8 +91,14 @@ const mergeBatch = async (params: {
   ctx: MergeContext;
   currentFormState: ConsolidatedFormState;
   transcript: string;
+  template?: Awaited<ReturnType<typeof getDefaultTemplate>>;
 }): Promise<MergeResult> => {
-  const userPrompt = buildUserPrompt(params.ctx, params.currentFormState, params.transcript);
+  const userPrompt = buildUserPrompt(
+    params.ctx,
+    params.currentFormState,
+    params.transcript,
+    params.template,
+  );
   const fullPrompt = `${SYSTEM_PROMPT}\n\n${userPrompt}`;
 
   const raw = await aiClientAudio.generate({ prompt: fullPrompt, responseFormat: "json" });
@@ -176,6 +202,9 @@ export const processAudioJob = async (db: PrismaClient, job: QstashAudioJob) => 
     );
 
     const currentFormState = consolidatedFormStateSchema.parse(session.currentFormState);
+    const template = currentFormState.templateId
+      ? await getTemplateById(db, job.profileId, currentFormState.templateId)
+      : await getDefaultTemplate(db, job.profileId);
 
     const merge = await mergeBatch({
       ctx: {
@@ -186,6 +215,7 @@ export const processAudioJob = async (db: PrismaClient, job: QstashAudioJob) => 
       },
       currentFormState,
       transcript: transcription.text,
+      template,
     });
 
     const breakdown = calculateCreditConsumptionBreakdown({

--- a/src/server/services/formTemplate.service.ts
+++ b/src/server/services/formTemplate.service.ts
@@ -1,0 +1,494 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+
+import {
+  SYSTEM_ANAMNESIS_FIELD_KEY_SET,
+  type CreateFormTemplateInput,
+  type FormFieldConfig,
+  type FormFieldType,
+  type UpdateFormTemplateInput,
+} from "~/schemas/form-template";
+
+type DbClient = PrismaClient | Prisma.TransactionClient;
+
+type DefaultField = {
+  key: string;
+  label: string;
+  description?: string;
+  order: number;
+  fieldType: FormFieldType;
+  isRequired?: boolean;
+  config?: FormFieldConfig;
+};
+
+type DefaultSection = {
+  name: string;
+  description?: string;
+  order: number;
+  fields: DefaultField[];
+};
+
+const templateInclude = {
+  sections: {
+    orderBy: { order: "asc" as const },
+    include: {
+      fields: {
+        orderBy: { order: "asc" as const },
+      },
+    },
+  },
+};
+
+export const DEFAULT_ANAMNESIS_TEMPLATE: DefaultSection[] = [
+  {
+    name: "Anamnese",
+    order: 0,
+    fields: [
+      {
+        key: "chiefComplaint",
+        label: "Queixa Principal",
+        order: 0,
+        fieldType: "TEXT",
+        isRequired: true,
+        config: { placeholder: "Descreva a queixa principal do paciente" },
+      },
+      {
+        key: "currentIllnessHistory",
+        label: "Historia da Doenca Atual",
+        order: 1,
+        fieldType: "TEXT",
+        isRequired: true,
+        config: { placeholder: "Descreva a historia da doenca atual" },
+      },
+      {
+        key: "treatmentResponse",
+        label: "Resposta ao Tratamento",
+        order: 2,
+        fieldType: "TEXT",
+      },
+      {
+        key: "symptomEvolution",
+        label: "Evolucao dos Sintomas",
+        order: 3,
+        fieldType: "TEXT",
+      },
+      {
+        key: "newEvents",
+        label: "Novos Eventos",
+        order: 4,
+        fieldType: "TEXT",
+      },
+      {
+        key: "nyhaClass",
+        label: "Classe NYHA",
+        order: 5,
+        fieldType: "NYHA_CLASS",
+        isRequired: true,
+      },
+      {
+        key: "hasPalpitations",
+        label: "Palpitacoes",
+        order: 6,
+        fieldType: "BOOLEAN",
+      },
+      {
+        key: "hasSyncope",
+        label: "Sincope",
+        order: 7,
+        fieldType: "BOOLEAN",
+      },
+      {
+        key: "hasEdema",
+        label: "Edema",
+        order: 8,
+        fieldType: "BOOLEAN",
+      },
+      {
+        key: "hasChestPain",
+        label: "Dor Toracica",
+        order: 9,
+        fieldType: "BOOLEAN",
+      },
+    ],
+  },
+  {
+    name: "Exame Fisico",
+    order: 1,
+    fields: [
+      { key: "weight", label: "Peso", order: 0, fieldType: "NUMBER", config: { unit: "kg", step: 0.1 } },
+      { key: "height", label: "Altura", order: 1, fieldType: "NUMBER", config: { unit: "cm", step: 0.1 } },
+      { key: "bpSystolic", label: "PA Sistolica", order: 2, fieldType: "NUMBER", config: { unit: "mmHg" } },
+      { key: "bpDiastolic", label: "PA Diastolica", order: 3, fieldType: "NUMBER", config: { unit: "mmHg" } },
+      { key: "heartRate", label: "Frequencia Cardiaca", order: 4, fieldType: "NUMBER", config: { unit: "bpm" } },
+      { key: "oxygenSaturation", label: "Saturacao O2", order: 5, fieldType: "NUMBER", config: { unit: "%" } },
+      { key: "heartAuscultation", label: "Ausculta Cardiaca", order: 6, fieldType: "TEXT" },
+      { key: "lungAuscultation", label: "Ausculta Pulmonar", order: 7, fieldType: "TEXT" },
+      { key: "peripheralPulses", label: "Pulsos Perifericos", order: 8, fieldType: "SHORT_TEXT" },
+      { key: "edemaGrade", label: "Grau de Edema", order: 9, fieldType: "SHORT_TEXT" },
+    ],
+  },
+  {
+    name: "Hipotese e Conduta",
+    order: 2,
+    fields: [
+      { key: "medications", label: "Medicamentos", order: 0, fieldType: "MEDICATIONS" },
+      { key: "diagnosticHypothesis", label: "Hipotese Diagnostica", order: 1, fieldType: "TEXT" },
+      { key: "conduct", label: "Conduta", order: 2, fieldType: "TEXT" },
+      { key: "nextRecallDate", label: "Data do Proximo Retorno", order: 3, fieldType: "DATE" },
+    ],
+  },
+];
+
+const normalizeJson = (value: unknown): Prisma.InputJsonValue | undefined => {
+  if (value == null) return undefined;
+  return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+};
+
+const normalizeResponses = (
+  value: Record<string, unknown> | undefined,
+): Prisma.InputJsonObject => {
+  return JSON.parse(JSON.stringify(value ?? {})) as Prisma.InputJsonObject;
+};
+
+const validateUniqueKeys = (sections: CreateFormTemplateInput["sections"]) => {
+  const keys = new Set<string>();
+  for (const section of sections) {
+    for (const field of section.fields) {
+      if (keys.has(field.key)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `A chave de campo "${field.key}" esta duplicada no template`,
+        });
+      }
+      keys.add(field.key);
+    }
+  }
+};
+
+const toSectionCreate = (
+  section: DefaultSection,
+): Prisma.AnamnesisFormSectionCreateWithoutTemplateInput => ({
+  name: section.name,
+  description: section.description,
+  order: section.order,
+  fields: {
+    create: section.fields.map((field) => ({
+      key: field.key,
+      label: field.label,
+      description: field.description,
+      order: field.order,
+      fieldType: field.fieldType,
+      isRequired: field.isRequired ?? false,
+      isVisible: true,
+      config: normalizeJson(field.config),
+      isSystemField: true,
+      systemKey: field.key,
+    })),
+  },
+});
+
+const createDefaultTemplate = (db: DbClient, profileId: string) => {
+  return db.anamnesisFormTemplate.create({
+    data: {
+      profileId,
+      name: "Formulario Padrao",
+      description: "Template padrao de anamnese cardiologica",
+      isDefault: true,
+      sections: {
+        create: DEFAULT_ANAMNESIS_TEMPLATE.map(toSectionCreate),
+      },
+    },
+    include: templateInclude,
+  });
+};
+
+export const seedDefaultTemplate = async (
+  db: DbClient,
+  profileId: string,
+) => {
+  const existing = await db.anamnesisFormTemplate.findFirst({
+    where: { profileId, isDefault: true },
+    include: templateInclude,
+  });
+
+  if (existing) return existing;
+
+  return createDefaultTemplate(db, profileId);
+};
+
+export const getDefaultTemplate = async (
+  db: PrismaClient,
+  profileId: string,
+) => seedDefaultTemplate(db, profileId);
+
+export const listTemplates = async (db: PrismaClient, profileId: string) => {
+  return db.anamnesisFormTemplate.findMany({
+    where: { profileId, isArchived: false },
+    orderBy: [{ isDefault: "desc" }, { updatedAt: "desc" }],
+    include: templateInclude,
+  });
+};
+
+export const getTemplateById = async (
+  db: PrismaClient,
+  profileId: string,
+  templateId: string,
+) => {
+  const template = await db.anamnesisFormTemplate.findFirst({
+    where: { id: templateId, profileId },
+    include: templateInclude,
+  });
+
+  if (!template) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Template nao encontrado" });
+  }
+
+  return template;
+};
+
+const toCustomSectionCreate = (
+  section: CreateFormTemplateInput["sections"][number],
+  systemFieldsByKey = new Map<string, { fieldType: FormFieldType; systemKey: string | null }>(),
+): Prisma.AnamnesisFormSectionCreateWithoutTemplateInput => ({
+  name: section.name,
+  description: section.description ?? undefined,
+  order: section.order,
+  isCollapsible: section.isCollapsible,
+  fields: {
+    create: section.fields.map((field) => {
+      const systemField = systemFieldsByKey.get(field.key);
+      const isKnownSystemField =
+        Boolean(systemField) ||
+        Boolean(field.isSystemField && SYSTEM_ANAMNESIS_FIELD_KEY_SET.has(field.key));
+
+      return {
+        key: field.key,
+        label: field.label,
+        description: field.description ?? undefined,
+        order: field.order,
+        fieldType: systemField?.fieldType ?? field.fieldType,
+        isRequired: field.isRequired,
+        isVisible: field.isVisible,
+        config: normalizeJson(field.config),
+        isSystemField: isKnownSystemField,
+        systemKey: isKnownSystemField ? (systemField?.systemKey ?? field.key) : null,
+      };
+    }),
+  },
+});
+
+export const createTemplate = async (
+  db: PrismaClient,
+  profileId: string,
+  input: CreateFormTemplateInput,
+) => {
+  validateUniqueKeys(input.sections);
+
+  return db.$transaction(async (tx) => {
+    if (input.isDefault) {
+      await tx.anamnesisFormTemplate.updateMany({
+        where: { profileId, isDefault: true },
+        data: { isDefault: false },
+      });
+    }
+
+    return tx.anamnesisFormTemplate.create({
+      data: {
+        profileId,
+        name: input.name,
+        description: input.description ?? undefined,
+        isDefault: input.isDefault,
+        sections: {
+          create: input.sections.map((section) => toCustomSectionCreate(section)),
+        },
+      },
+      include: templateInclude,
+    });
+  });
+};
+
+export const updateTemplate = async (
+  db: PrismaClient,
+  profileId: string,
+  input: UpdateFormTemplateInput,
+) => {
+  const existing = await getTemplateById(db, profileId, input.id);
+  const sections = input.sections;
+
+  if (sections) {
+    validateUniqueKeys(sections);
+
+    const incomingFieldsByKey = new Map(
+      sections.flatMap((section) => section.fields.map((field) => [field.key, field] as const)),
+    );
+
+    for (const systemField of existing.sections.flatMap((section) =>
+      section.fields.filter((field) => field.isSystemField),
+    )) {
+      const incoming = incomingFieldsByKey.get(systemField.key);
+      if (!incoming) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `O campo do sistema "${systemField.label}" nao pode ser removido`,
+        });
+      }
+
+      if (incoming.fieldType !== systemField.fieldType) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `O tipo do campo do sistema "${systemField.label}" nao pode ser alterado`,
+        });
+      }
+    }
+  }
+
+  const systemFieldsByKey = new Map(
+    existing.sections
+      .flatMap((section) => section.fields)
+      .filter((field) => field.isSystemField)
+      .map((field) => [
+        field.key,
+        {
+          fieldType: field.fieldType as FormFieldType,
+          systemKey: field.systemKey,
+        },
+      ]),
+  );
+
+  return db.$transaction(async (tx) => {
+    if (input.isDefault) {
+      await tx.anamnesisFormTemplate.updateMany({
+        where: { profileId, isDefault: true, id: { not: input.id } },
+        data: { isDefault: false },
+      });
+    }
+
+    await tx.anamnesisFormTemplate.update({
+      where: { id: input.id },
+      data: {
+        name: input.name,
+        description: input.description,
+        isDefault: input.isDefault,
+      },
+    });
+
+    if (sections) {
+      await tx.anamnesisFormSection.deleteMany({
+        where: { templateId: input.id },
+      });
+
+      for (const section of sections) {
+        await tx.anamnesisFormSection.create({
+          data: {
+            templateId: input.id,
+            ...toCustomSectionCreate(section, systemFieldsByKey),
+          },
+        });
+      }
+    }
+
+    return tx.anamnesisFormTemplate.findUniqueOrThrow({
+      where: { id: input.id },
+      include: templateInclude,
+    });
+  });
+};
+
+export const setDefaultTemplate = async (
+  db: PrismaClient,
+  profileId: string,
+  templateId: string,
+) => {
+  const template = await getTemplateById(db, profileId, templateId);
+  if (template.isArchived) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Templates arquivados nao podem ser padrao",
+    });
+  }
+
+  return db.$transaction(async (tx) => {
+    await tx.anamnesisFormTemplate.updateMany({
+      where: { profileId, isDefault: true },
+      data: { isDefault: false },
+    });
+
+    return tx.anamnesisFormTemplate.update({
+      where: { id: templateId },
+      data: { isDefault: true },
+      include: templateInclude,
+    });
+  });
+};
+
+export const duplicateTemplate = async (
+  db: PrismaClient,
+  profileId: string,
+  templateId: string,
+) => {
+  const template = await getTemplateById(db, profileId, templateId);
+
+  return db.anamnesisFormTemplate.create({
+    data: {
+      profileId,
+      name: `${template.name} (copia)`,
+      description: template.description,
+      isDefault: false,
+      sections: {
+        create: template.sections.map((section) => ({
+          name: section.name,
+          description: section.description,
+          order: section.order,
+          isCollapsible: section.isCollapsible,
+          fields: {
+            create: section.fields.map((field) => ({
+              key: field.key,
+              label: field.label,
+              description: field.description,
+              order: field.order,
+              fieldType: field.fieldType,
+              isRequired: field.isRequired,
+              isVisible: field.isVisible,
+              config: normalizeJson(field.config),
+              isSystemField: field.isSystemField,
+              systemKey: field.systemKey,
+            })),
+          },
+        })),
+      },
+    },
+    include: templateInclude,
+  });
+};
+
+export const archiveTemplate = async (
+  db: PrismaClient,
+  profileId: string,
+  templateId: string,
+) => {
+  const template = await getTemplateById(db, profileId, templateId);
+
+  if (template.isDefault) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Defina outro template como padrao antes de arquivar este",
+    });
+  }
+
+  return db.anamnesisFormTemplate.update({
+    where: { id: templateId },
+    data: { isArchived: true },
+  });
+};
+
+export const sanitizeCustomResponses = (
+  responses: Record<string, unknown> | undefined,
+) => {
+  const filtered = Object.fromEntries(
+    Object.entries(responses ?? {}).filter(
+      ([key]) => !SYSTEM_ANAMNESIS_FIELD_KEY_SET.has(key),
+    ),
+  );
+
+  return normalizeResponses(filtered);
+};

--- a/src/server/services/patient.service.ts
+++ b/src/server/services/patient.service.ts
@@ -21,6 +21,16 @@ export const getFullProfile = async (
             physicalExam: true,
             medications: true,
             consultation: { select: { id: true, date: true, type: true } },
+            template: {
+              include: {
+                sections: {
+                  orderBy: { order: "asc" },
+                  include: {
+                    fields: { orderBy: { order: "asc" } },
+                  },
+                },
+              },
+            },
           },
         },
         consultations: {
@@ -57,6 +67,16 @@ export const getAnamnesisPaginated = async (
           physicalExam: true,
           medications: true,
           consultation: { select: { id: true, date: true, type: true } },
+          template: {
+            include: {
+              sections: {
+                orderBy: { order: "asc" },
+                include: {
+                  fields: { orderBy: { order: "asc" } },
+                },
+              },
+            },
+          },
         },
       }),
     ]);

--- a/src/server/services/profile.service.ts
+++ b/src/server/services/profile.service.ts
@@ -2,18 +2,28 @@ import { type PrismaClient } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 
 import {
+  type CreateDoctorBySuperAdminInput,
   type CreateProfileInput,
   type UpdateProfileInput,
 } from "~/schemas/profile";
 import { grantSignupBonus } from "~/server/services/credits/creditLedger.service";
+import { seedDefaultTemplate } from "~/server/services/formTemplate.service";
+import { SupabaseService } from "~/server/supabase/supabase-admin";
 
 export const createProfile = async (
   db: PrismaClient,
   data: CreateProfileInput,
 ) => {
-  const profile = await db.profile.create({
-    data: {
+  const profile = await db.profile.upsert({
+    where: { id: data.id },
+    create: {
       id: data.id,
+      email: data.email,
+      name: data.name,
+      phone: data.phone,
+      photoUrl: data.photoUrl,
+    },
+    update: {
       email: data.email,
       name: data.name,
       phone: data.phone,
@@ -22,6 +32,7 @@ export const createProfile = async (
   });
 
   await grantSignupBonus(db, profile.id);
+  await seedDefaultTemplate(db, profile.id);
 
   return profile;
 };
@@ -37,6 +48,7 @@ export const getProfileById = async (db: PrismaClient, id: string) => {
 
     if (profile) {
       await grantSignupBonus(db, profile.id);
+      await seedDefaultTemplate(db, profile.id);
     }
 
     return profile;
@@ -62,6 +74,78 @@ export const getAllProfiles = async (db: PrismaClient) => {
       code: "INTERNAL_SERVER_ERROR",
       message: "Erro ao listar perfis",
     });
+  }
+};
+
+export const assertSuperAdmin = async (db: PrismaClient, profileId: string) => {
+  const profile = await db.profile.findUnique({
+    where: { id: profileId },
+    select: { id: true, superAdmin: true },
+  });
+
+  if (!profile?.superAdmin) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Acesso restrito a administradores do sistema",
+    });
+  }
+
+  return profile;
+};
+
+export const createDoctorBySuperAdmin = async (
+  db: PrismaClient,
+  superAdminProfileId: string,
+  input: CreateDoctorBySuperAdminInput,
+) => {
+  await assertSuperAdmin(db, superAdminProfileId);
+
+  const existingProfile = await db.profile.findUnique({
+    where: { email: input.email },
+    select: { id: true },
+  });
+
+  if (existingProfile) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message: "Ja existe um medico cadastrado com este email",
+    });
+  }
+
+  const { data, error } = await SupabaseService.client.auth.admin.createUser({
+    email: input.email,
+    password: input.password,
+    email_confirm: input.emailConfirm,
+    user_metadata: {
+      name: input.name,
+    },
+  });
+
+  if (error) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: error.message || "Erro ao criar usuario no Supabase",
+    });
+  }
+
+  const authUser = data.user;
+  if (!authUser) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Supabase nao retornou o usuario criado",
+    });
+  }
+
+  try {
+    return await createProfile(db, {
+      id: authUser.id,
+      email: input.email,
+      name: input.name,
+      phone: input.phone,
+    });
+  } catch (error) {
+    await SupabaseService.client.auth.admin.deleteUser(authUser.id);
+    throw error;
   }
 };
 


### PR DESCRIPTION
# Description
This feature introduces the ability for doctors to create, edit, and use personalized anamnesis form templates. It enhances the existing anamnesis workflow by allowing dynamic form sections and fields, with the default anamnesis form serving as a base.

Key functionalities:
- New database models for form templates, sections, and fields.
- Backend services and API endpoints for managing templates.
- Dynamic rendering of form fields and sections in the anamnesis wizard.
- Integration of custom responses into anamnesis data storage and display.
- UI for doctors to manage their templates.
- Updates to audio anamnesis to utilize templates.

# Justification
This provides greater flexibility and customization for doctors, allowing them to tailor anamnesis forms to their specific needs, specialties, and patient types. This improves data collection efficiency and relevance, leading to more comprehensive patient records.

Closes #44 